### PR TITLE
feat(retrieval): decouple index from prompt budget, add leak-free eval gate

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -33,3 +33,5 @@ jobs:
         run: npm run test:python
       - name: Run integration tests
         run: node test/integration/all.js
+      - name: Retrieval quality gate (leak-free hard corpus)
+        run: npm run validate:retrieval

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -28,23 +28,63 @@ low-priority files rather than collapsing signatures to bare line anchors.
 
 Always run `sigmap ask` (or `sigmap --query`) before searching for files relevant to a task.
 
-## deps
+## todos
 ```
-src/extractors/python_ast.py ← ast
+gen-context.js:22350  # TODO: s');
 ```
 
-## changes (last 5 commits — 0 seconds ago)
+## changes (last 5 commits — 10 days ago)
 ```
-src/extractors/csharp.js                      ~extract  ~extractMembers
-src/extractors/dart.js                        ~extract  ~extractMembers
-src/extractors/go.js                          ~extract  ~extractInterfaceMethods
-src/extractors/java.js                        ~extract  ~extractMembers
-src/extractors/kotlin.js                      ~extract  ~extractMembers
-src/extractors/php.js                         ~extract  ~extractMembers
-src/extractors/rust.js                        ~extract  ~extractMethods  ~extractReturnType
-src/extractors/scala.js                       ~extract  ~extractMembers
-src/extractors/swift.js                       ~extract  ~extractMembers  ~extractArrowType
-src/evidence/pack.js                          +riskFactorsFor  ~parseAnchor  ~buildEvidencePack  ~formatMarkdown
+src/graph/builder.js                          ~extractFileDeps
+src/retrieval/ranker.js                       ~_buildSigIndexFromCache  ~_enrichSigIndexFromStrategy
+gen-context.js                                +whose  +extractClassMembers  +stripComments  +maskCode
+src/extractors/javascript.js                  +whose  +extractClassMembers  ~whose  ~extractClassMembers
+src/extractors/scan.js                        +stripComments  +maskCode  +readBalanced
+src/extractors/typescript.js                  +extractClassMembers  ~extractClassMembers  ~extract  ~extractBlock
+src/verify/arity.js                           +exist  +cleanSig  +parseParams  +buildArityIndex
+src/verify/hallucination-guard.js             +whose  ~buildSymbolSet  ~verify
+```
+
+## .
+
+### gen-context.js
+```
+function __require(key)  :9-20
+function __git(args, opts = {})  :21630-21633
+function __tryGit(args, opts = {})  :21634-21637
+function requireSourceOrBundled(key)  :21642-21649
+function isDockerfile(filename)  :21695-21697
+function loadIgnorePatterns(cwd)  :21702-21715
+function matchesIgnore(relPath, patterns)  :21717-21738
+function walkDir(dir, exclude, maxDepth, depth = 0)  :21743-21766
+function buildFileList(cwd, config)  :21768-21779
+function collectTestEntries(cwd, config, existing)  :21790-21816  # Source files a project declares as its own entrypoints in pa
+function declaredEntrypoints(cwd, config, existing)  :21818-21838
+function getExtractor(name)  :21844-21854
+function detectAndExtract(filePath, content, maxSigsPerFile)  :21856-21874
+function extractFileDeps(filePath, content, config) → string[]  :21876-21886  # Extract absolute dependency paths from a single file
+function extractSignatureName(sig)  :21888-21892
+function annotateCoverage(sigs, testIndex, enabled)  :21894-21904
+function nextRecentMtime()  :21925-21927
+function estimateTokens(str) → number  :21929-21931  # Estimate token count from character count (chars/4, ±5%)
+function isTestFile(filePath)  :21933-21935
+function isConfigFile(filePath)  :21937-21940
+function isGeneratedFile(filePath)  :21942-21944
+function isMockFile(filePath)  :21946-21951
+function computeEffectiveMaxTokens(fileEntries, config) → number  :21968-22006  # Compute the effective token budget based on repo size and co
+function applyTokenBudget(fileEntries, maxTokens)  :22008-22076
+function getRecentlyCommittedFiles(cwd, count)  :22107-22115
+… +45 more signatures
+```
+
+### gen-project-map.js
+```
+function detectInvokedAs()  :27-37
+function walkDir(dir, excludeSet, maxDepth, depth, results)  :77-90
+function buildFileList(cwd, srcDirs, exclude, maxDepth)  :92-103
+function runAnalyzer(name, files, cwd)  :108-116
+function formatOutput(sections)  :121-151
+function main()  :156-191
 ```
 
 ## packages
@@ -52,106 +92,60 @@ src/evidence/pack.js                          +riskFactorsFor  ~parseAnchor  ~bu
 ### packages/adapters/claude.js
 ```
 module.exports = { name, format, outputPath, write }  :124-124
-function format(context, opts = {}) → string  :58-69
+function format(context, opts = {}) → string  :58-69  # Format context suited for CLAUDE
 function _confidenceMeta(opts)  :71-78
-function outputPath(cwd) → string  :85-87
-function write(context, cwd, opts = {})  :96-122
+function outputPath(cwd) → string  :85-87  # Return the output file path for this adapter
+function write(context, cwd, opts = {})  :96-122  # Write signatures into CLAUDE
 ```
 
 ### packages/adapters/codex.js
 ```
 module.exports = { name, format, outputPath, write }  :74-74
-function format(context, opts = {}) → string  :27-30
-function outputPath(cwd) → string  :37-39
-function write(context, cwd, opts = {})  :49-72
+function format(context, opts = {}) → string  :27-30  # Format context for AGENTS
+function outputPath(cwd) → string  :37-39  # Return the output file path for this adapter
+function write(context, cwd, opts = {})  :49-72  # Write signatures into AGENTS
 ```
 
 ### packages/adapters/copilot.js
 ```
 module.exports = { name, format, outputPath, write }  :93-93
-function format(context, opts = {}) → string  :25-40
+function format(context, opts = {}) → string  :25-40  # Format context for GitHub Copilot instructions
 function _confidenceMeta(opts)  :42-49
-function outputPath(cwd) → string  :56-58
-function write(context, cwd, opts = {})  :68-91
+function outputPath(cwd) → string  :56-58  # Return the output file path for this adapter
+function write(context, cwd, opts = {})  :68-91  # Write signatures into copilot-instructions
 ```
 
 ### packages/adapters/cursor.js
 ```
 module.exports = { name, format, outputPath }  :56-56
-function format(context, opts = {}) → string  :23-36
+function format(context, opts = {}) → string  :23-36  # Format context for Cursor rules file
 function _confidenceMeta(opts)  :38-45
-function outputPath(cwd) → string  :52-54
+function outputPath(cwd) → string  :52-54  # Return the output file path for this adapter
 ```
 
 ### packages/adapters/gemini.js
 ```
 module.exports = { name, format, outputPath, write }  :104-104
-function format(context, opts = {}) → string  :31-51
-function outputPath(cwd) → string  :58-60
-function write(context, cwd, opts = {})  :70-93
+function format(context, opts = {}) → string  :31-51  # Format context as a Gemini system instruction
+function outputPath(cwd) → string  :58-60  # Return the output file path for this adapter
+function write(context, cwd, opts = {})  :70-93  # Write signatures into gemini-context
 function _confidenceMeta(opts)  :95-102
-```
-
-### packages/adapters/index.js
-```
-module.exports = { getAdapter, listAdapters, adapt, outputsToAdapters }  :81-81
-function getAdapter(name) → { name: string, format: F  :26-38
-function listAdapters() → string[]  :44-46
-function adapt(context, adapterName, opts = {}) → string  :55-64
-function outputsToAdapters(outputs) → string[]  :72-79
-```
-
-### packages/adapters/llm-full.js
-```
-module.exports = { name: 'llm-full', format, outputPath, write }  :4-4
-function outputPath(cwd)  :6-6
-function format(context, opts)  :8-20
-function write(context, cwd, opts)  :22-25
 ```
 
 ### packages/adapters/openai.js
 ```
 module.exports = { name, format, outputPath }  :70-70
-function format(context, opts = {}) → string  :29-49
-function outputPath(cwd) → string  :57-59
+function format(context, opts = {}) → string  :29-49  # Format context as an OpenAI system prompt
+function outputPath(cwd) → string  :57-59  # Return the output file path for this adapter
 function _confidenceMeta(opts)  :61-68
-```
-
-### packages/adapters/willow.js
-```
-module.exports = { name, format, outputPath, write }  :200-200
-function format(context, opts = {}) → string  :36-40
-function outputPath(cwd) → string  :47-49
-function generateAtomId(filepath) → string  :57-63
-async function fetchWithTimeout(url, opts, timeoutMs) → Promise<Response>  :72-80
-async function postAtomWithRetry(atom, mcpUrl, timeoutMs, maxRetries) → Promise<boolean>  :90-142
-async function write(context, cwd, opts = {}) → Promise<void>  :155-198
 ```
 
 ### packages/adapters/windsurf.js
 ```
 module.exports = { name, format, outputPath }  :56-56
-function format(context, opts = {}) → string  :23-36
+function format(context, opts = {}) → string  :23-36  # Format context for Windsurf rules file
 function _confidenceMeta(opts)  :38-45
-function outputPath(cwd) → string  :52-54
-```
-
-### packages/cli/index.js
-```
-module.exports = { CLI_ENTRY, run }  :58-63
-function run(argv, cwd) → void  :36-56
-```
-
-### packages/core/index.js
-```
-module.exports = { extract, rank, buildSigIndex, scan, score, adapt }  :254-267
-function _resolveExtractor(language)  :64-71
-function extract(src, language) → string[]  :91-120
-function rank(query, sigIndex, opts) → { file: string, score: nu  :143-150
-function buildSigIndex(cwd) → Map<string, string[]>  :162-169
-function scan(sigs, filePath) → { safe: string[], redacte  :185-192
-function score(cwd) → { * score: number, * grad  :215-222
-function adapt(context, adapterName, opts = {}) → string  :241-249
+function outputPath(cwd) → string  :52-54  # Return the output file path for this adapter
 ```
 
 ### packages/core/README.md
@@ -176,128 +170,52 @@ code-fence ---
 
 ## src
 
-### src/config/defaults.js
+### src/graph/builder.js
 ```
-module.exports = { DEFAULTS }  :165-165
-```
-
-### src/extractors/csharp.js
-```
-module.exports = { extract }  :71-71
-function extract(src) → string[]  :12-71
-function extractBlock(src, startIndex)  :35-44
-function extractMembers(block)  :46-59
-function normalizeParams(params)  :61-64
-function normalizeType(type)  :66-69
-```
-
-### src/extractors/dart.js
-```
-module.exports = { extract }  :84-84
-function extract(src) → string[]  :12-84
-function extractBlock(src, startIndex)  :54-63
-function extractMembers(block)  :65-77
-function normalizeParams(params)  :79-81
-```
-
-### src/extractors/go.js
-```
-module.exports = { extract }  :81-81
-function extract(src) → string[]  :12-81
-function extractBlock(src, startIndex)  :51-60
-function extractInterfaceMethods(block)  :62-74
-function normalizeParams(params)  :76-79
-```
-
-### src/extractors/java.js
-```
-module.exports = { extract }  :71-71
-function extract(src) → string[]  :12-71
-function extractBlock(src, startIndex)  :34-44
-function extractMembers(block)  :46-59
-function normalizeParams(params)  :61-64
-function normalizeType(type)  :66-69
-```
-
-### src/extractors/kotlin.js
-```
-module.exports = { extract }  :90-90
-function extract(src) → string[]  :12-90
-function extractBlock(src, startIndex)  :54-63
-function extractMembers(block)  :65-90
-function normalizeParams(params)  :81-88
-```
-
-### src/extractors/php.js
-```
-module.exports = { extract }  :96-96
-function extract(src) → string[]  :12-96
-function extractBlock(src, startIndex)  :58-67
-function extractMembers(block)  :69-96
-function normalizeParams(params)  :86-89
-function normalizeType(type)  :91-94
-```
-
-### src/extractors/rust.js
-```
-module.exports = { extract }  :110-110
-function extract(src) → string[]  :12-110
-function extractBlock(src, startIndex)  :72-81
-function extractMethods(block)  :83-110
-function normalizeParams(params)  :97-100
-function extractReturnType(afterParen)  :102-110
-```
-
-### src/extractors/scala.js
-```
-module.exports = { extract }  :88-88
-function extract(src) → string[]  :12-88
-function extractBlock(src, startIndex)  :47-56
-function extractMembers(block)  :58-88
-function normalizeParams(params)  :74-81
-function normalizeType(type)  :83-86
-```
-
-### src/extractors/swift.js
-```
-module.exports = { extract }  :97-97
-function extract(src) → string[]  :12-97
-function extractBlock(src, startIndex)  :54-63
-function extractMembers(block)  :65-97
-function normalizeParams(params)  :80-87
-function extractArrowType(str)  :89-97
+module.exports = { build, buildFromCwd, extractFileDeps, normalizePath, loadAliasMap, resolveAlias }  :503-503
+function normalizePath(p)  :18-20
+function probeJs(base, fileSet) → string|null  :41-54  # Probe an absolute base path for a JS/TS module file in fileS
+function resolveJsPath(dir, importStr, fileSet) → string|null  :63-65  # Resolve a JS/TS relative import string to an absolute path i
+function stripJsonc(src)  :71-85  # Strip comments and trailing commas so a tsconfig/jsconfig (J
+function loadAliasMap(cwd) → { baseUrl: string|null, e  :97-118  # Load the JS/TS path-alias map from tsconfig
+function resolveAlias(spec, aliasMap, fileSet) → string|null  :127-151  # Resolve a non-relative JS/TS import specifier through the al
+function escapeRegex(s)  :158-160  # Resolve an R `source(
+function resolveRPath(dir, importStr, fileSet, cwd)  :162-177
+function extractFileDeps(filePath, content, fileSet, cwd, ctx) → string[]  :191-287  # Extract absolute dependency paths from a single file
+function build(files, cwd, ctx) → { forward: Map<string,str  :396-435  # Build a forward and reverse dependency graph for all given f
+function buildFromCwd(cwd, opts) → { forward: Map<string,str  :447-501  # Build a dependency graph scoped to a single cwd by walking a
 ```
 
 ### src/mcp/server.js
 ```
-module.exports = { start }  :141-141
+module.exports = { start }  :142-142
 function respond(id, result)  :28-30
 function respondError(id, code, message)  :32-36
-function dispatch(msg, cwd)  :41-108
-function start(cwd)  :113-139
+function dispatch(msg, cwd)  :41-109
+function start(cwd)  :114-140
 ```
 
-### src/retrieval/enrich-from-maps.js
+### src/retrieval/ranker.js
 ```
-module.exports = { enrichWithSurfaces }  :55-55
-function enrichWithSurfaces(index, cwd) → number  :25-53
-```
-
-### src/analysis/coverage-score.js
-```
-module.exports = { coverageScore, CODE_EXTS }  :105-105
-function coverageScore(cwd, fileEntries, config)  :41-90
-function _walk(dir, excludeSet, out)  :92-103
-```
-
-### src/analysis/diagnostics.js
-```
-module.exports = { formatFileDecision, computeFileMetrics, explainInclusion, explainExclusion, estimateTokens }  :80-86
-function estimateTokens(text)  :14-16
-function formatFileDecision(entry, decision, reason, score = null)  :18-26
-function computeFileMetrics(entry)  :28-41
-function explainInclusion(fileEntries, budgetLimit)  :43-74
-function explainExclusion(dropped, reason)  :76-78
+module.exports = { rank, buildSigIndex, scoreFile, _queryWants, detectIntents, formatRankTable, formatRankJSON, DEFAULT_WEIGHTS, GRAPH_BOOST_AMOUNTS, CENTRALITY_BLEND_WEIGHT, detectIntent }  :760-760
+function _queryWants(queryTokens)  :85-92  # Which penalised categories the query is explicitly asking fo
+function _computePenalty(filePath, wants)  :94-108
+function _computeHubs(graph)  :111-122
+function _graphKeys(p)  :129-133
+function _graphGet(map, absPath)  :134-140
+function _registerKeys(map, absPath, value)  :141-143
+function _isHub(filePath)  :145-149
+function scoreFile(filePath, sigs, queryTokens, weights, wants) → { score: number, signals:  :160-221  # Score a single file against a query, returning detailed sign
+function rank(query, sigIndex, opts) → { file: string, score: nu  :241-331  # Rank all files in a signature index against a query
+function _parseContextFile(contextPath) → Map<string, string[]>  :478-510  # Parse a single context file into a Map<filePath, string[]>
+function _mergeSigIndex(target, source)  :513-521  # Merge source index into target; prefer non-empty sig lists
+function _buildSigIndexFromCache(cwd) → Map<string, string[]>  :528-548  # Load signatures from
+function _enrichSigIndexFromStrategy(cwd, index) → Map<string, string[]>  :556-587  # Hot-cold and per-module strategies store most signatures out
+function buildSigIndex(cwd, opts) → Map<string, string[]>  :604-637  # Build a signature index from the generated context file
+function formatRankTable(results, query) → string  :646-682  # Format ranked results as a markdown table string
+function formatRankJSON(results, query) → object  :691-706  # Format ranked results as a structured JSON-serialisable obje
+function detectIntents(query) → string[]  :739-753  # Every intent whose pattern matches, strongest first
+function detectIntent(query)  :756-758  # Primary intent
 ```
 
 ### src/cache/freshen.js
@@ -305,91 +223,97 @@ function explainExclusion(dropped, reason)  :76-78
 module.exports = { freshen }  :123-123
 function _readConfig(cwd)  :35-40
 function _pkgVersion(cwd)  :42-45
-function _contextMtime(cwd)  :48-54
+function _contextMtime(cwd)  :48-54  # Newest mtime among existing generated context files, or 0 if
 function _walk(dir, exclude, out, depth, maxDepth)  :56-66
-function freshen(cwd, opts = {}) → number  :74-121
+function freshen(cwd, opts = {}) → number  :74-121  # Re-extract source files changed since the last generate; dro
 ```
 
-### src/cache/sig-cache.js
+### src/config/defaults.js
 ```
-module.exports = { loadCache, saveCache, getChangedFiles, updateCacheEntries }  :105-105
-function cachePath(cwd)  :19-21
-function loadCache(cwd, currentVersion) → Map<string, { mtime: numb  :32-42
-function saveCache(cwd, currentVersion, cache)  :51-61
-function getChangedFiles(files, cache) → { changed: string[], unch  :71-88
-function updateCacheEntries(cache, extracted)  :96-103
+module.exports = { DEFAULTS }  :175-175
 ```
 
 ### src/config/loader.js
 ```
 module.exports = { loadConfig, loadBaseConfig }  :313-313
-function loadBaseConfig(extendsVal, cwd)  :9-54
-function detectAutoSrcDirs(cwd, excludeList) → string[]  :99-114
-function _legacyDetectAutoSrcDirs(cwd, excludeList) → string[]  :123-225
-function loadConfig(cwd) → object  :236-307
+function loadBaseConfig(extendsVal, cwd)  :9-64
+function detectAutoSrcDirs(cwd, excludeList) → string[]  :99-114  # Detect source directories for the given project root
+function _legacyDetectAutoSrcDirs(cwd, excludeList) → string[]  :123-218  # Legacy source directory detection (fallback)
+function loadConfig(cwd) → object  :236-307  # Load and merge configuration for a given working directory
 function deepClone(obj)  :309-311
+```
+
+### src/config/tune.js
+```
+module.exports = { buildTuneProposal, applyTuneProposal, formatTuneProposal, JUNK_DIRS, TOKENS_PER_FILE }  :210-210
+function _readUserConfig(cwd)  :45-51  # Raw user config file content, or null when absent/unparsable
+function _countSourceFiles(cwd, roots, exclude, depth = 5)  :54-72  # Count source files under `roots` (relative to cwd), depth-ca
+function _monorepoMarker(cwd)  :75-84  # The workspace marker present at cwd, or null
+function buildTuneProposal(cwd) → { changes: Array<{key:str  :94-176  # Build the recommended config diff for a repo
+function applyTuneProposal(cwd, proposal) → { path: string, applied:   :184-190  # Merge a proposal's changes into gen-context
+function formatTuneProposal(proposal)  :193-208  # Human rendering of a proposal (one block per change, reason 
 ```
 
 ### src/conventions/ci.js
 ```
 module.exports = { ciGate, DEFAULT_MIN }  :48-48
-function ciGate(result, opts = {}, prior = null) → { score:number, min:numbe  :25-46
+function ciGate(result, opts = {}, prior = null) → { score:number, min:numbe  :25-46  # Evaluate the consistency gate
 ```
 
 ### src/conventions/conflicts.js
 ```
 module.exports = { analyzeConflicts, toNamingStyle, renameSuggestion }  :111-111
-function _splitName(filename)  :13-18
-function _words(stem)  :21-29
-function toNamingStyle(stem, style) → string  :39-49
-function renameSuggestion(filename, dominantStyle)  :52-56
-function analyzeConflicts(result) → { hasConflicts: boolean,   :72-109
+function _splitName(filename)  :13-18  # Split a file name into its stem (before the first dot) and t
+function _words(stem)  :21-29  # Break a stem into lowercase word parts regardless of its cur
+function toNamingStyle(stem, style) → string  :39-49  # Convert a file stem to a target naming style
+function renameSuggestion(filename, dominantStyle)  :52-56  # Rename suggestion to bring a file to the dominant naming sty
+function analyzeConflicts(result) → { hasConflicts: boolean,   :72-109  # Analyze an `extractConventions` result for conflicts
 ```
 
 ### src/conventions/extract.js
 ```
 module.exports = { classifyNaming, scoreConvention, extractConventions }  :188-188
-function classifyNaming(basename) → 'PascalCase'|'camelCase'|  :40-51
-function scoreConvention(labels, refs) → { dominant: string|null,   :65-103
-function _jsExportStyle(src)  :106-188
-function _detectTestFramework(cwd, files)  :122-150
-function extractConventions(cwd, files) → { fileNaming: object, exp  :159-186
+function classifyNaming(basename) → 'PascalCase'|'camelCase'|  :40-51  # Classify a file's base name (without extension) into a namin
+function scoreConvention(labels, refs) → { dominant: string|null,   :65-103  # Score a set of categorical observations into a dominant conv
+function _jsExportStyle(src)  :106-188  # Detect JS/TS export style for a single file's source
+function _detectTestFramework(cwd, files)  :122-150  # Detect the test framework in use from manifests + source heu
+function extractConventions(cwd, files) → { fileNaming: object, exp  :159-186  # Extract repo coding conventions for the scoped languages (TS
 ```
 
 ### src/conventions/fix.js
 ```
 module.exports = { buildFixList }  :61-61
-function _renamePath(relPath, style)  :24-31
-function buildFixList(cwd, files, conventions) → { dominant: string|null,   :40-59
+function _renamePath(relPath, style)  :24-31  # Rename a file path's basename to the target naming style (ke
+function buildFixList(cwd, files, conventions) → { dominant: string|null,   :40-59  # Build the exhaustive rename checklist for the dominant file-
 ```
 
 ### src/conventions/inject.js
 ```
 module.exports = { renderConventionsBlock, injectConventions, START, END }  :98-98
 function _conventionLine(label, conv)  :29-38
-function renderConventionsBlock(result, version) → string  :46-72
-function injectConventions(existing, block) → string  :82-96
+function renderConventionsBlock(result, version) → string  :46-72  # Render the conventions block (including its start/end marker
+function injectConventions(existing, block) → string  :82-96  # Inject (or replace) the conventions block in existing CLAUDE
 ```
 
 ### src/conventions/report.js
 ```
 module.exports = { scoreReport, snapshot, overallScore }  :75-75
-function overallScore(result)  :14-22
-function scoreReport(result, prior) → { conventions: object[],   :31-55
-function snapshot(result, ts)  :62-73
+function overallScore(result)  :14-22  # File-count-weighted mean of the scored conventions' dominant
+function scoreReport(result, prior) → { conventions: object[],   :31-55  # Build a consistency report with trend vs a prior snapshot
+function snapshot(result, ts)  :62-73  # A compact, persistable snapshot of a run (one line in the hi
 ```
 
 ### src/conventions/update.js
 ```
 module.exports = { changedSince, planUpdate }  :46-46
-function changedSince(files, sinceMs) → string[]  :20-26
-function planUpdate(cwd, files, snapshotPath) → { snapshotExists: boolean  :35-44
+function changedSince(files, sinceMs) → string[]  :20-26  # Source files modified after a reference time
+function planUpdate(cwd, files, snapshotPath) → { snapshotExists: boolean  :35-44  # Decide whether the conventions snapshot needs a rescan
 ```
 
 ### src/create/orchestrate.js
 ```
 module.exports = { orchestrate, TOTAL }  :86-86
-function orchestrate(ctx = {}, cwd) → { task: string|null, step  :34-84
+function orchestrate(ctx = {}, cwd) → { task: string|null, step  :34-84  # Run the create pipeline over whatever inputs are available
 ```
 
 ### src/daemon/daemon.js
@@ -398,52 +322,12 @@ module.exports = { start, stop, status, pidFile, logFile, isAlive, readPid }  :2
 function daemonDir(cwd)  :22-24
 function pidFile(cwd)  :26-28
 function logFile(cwd)  :30-32
-function isAlive(pid)  :35-44
-function readPid(cwd)  :47-55
+function isAlive(pid)  :35-44  # True if a process with this PID exists (signal 0 probes with
+function readPid(cwd)  :47-55  # Read the recorded PID, or null if the file is missing/unpars
 function removePidFile(cwd)  :57-61
 function status(cwd) → { running: boolean, pid:   :66-72
-function start(cwd, opts = {}) → { status: 'started'|'alre  :82-105
-function stop(cwd) → { status: 'stopped'|'not-  :112-124
-```
-
-### src/discovery/framework-detector.js
-```
-module.exports = { detectFrameworks }  :7-7
-function detectFrameworks(cwd)  :9-57
-function _readDeps(cwd)  :59-64
-function _readFile(p)  :66-68
-function _existsAnywhere(cwd, filename, maxDepth)  :70-74
-function _walkFind(dir, name, depth)  :76-88
-```
-
-### src/discovery/language-detector.js
-```
-module.exports = { detectLanguages }  :7-7
-function detectLanguages(cwd)  :26-61
-function _walkDepth(dir, depth, extCount)  :63-76
-```
-
-### src/discovery/r-manifest.js
-```
-module.exports = { readDescription, readNamespace, collectLocalDefs }  :176-176
-function readDescription(cwd) → object|null  :28-59
-function splitDeps(value)  :66-71
-function readNamespace(cwd) → object|null  :88-132
-function splitArgs(raw)  :134-136
-function stripQuotes(s)  :138-140
-function collectLocalDefs(rFiles) → Map<string, string>  :150-174
-```
-
-### src/discovery/sigmapignore.js
-```
-module.exports = { loadIgnorePatterns, matchesIgnorePattern }  :6-6
-function loadIgnorePatterns(cwd)  :8-19
-function matchesIgnorePattern(dirName, patterns)  :21-29
-```
-
-### src/discovery/source-root-registry.js
-```
-module.exports = { REGISTRY }  :175-175
+function start(cwd, opts = {}) → { status: 'started'|'alre  :82-105  # Launch a detached `--watch` process
+function stop(cwd) → { status: 'stopped'|'not-  :112-124  # Stop the running watcher (SIGTERM) and clear its PID file
 ```
 
 ### src/discovery/source-root-resolver.js
@@ -471,386 +355,220 @@ module.exports = { diagnose, formatDoctor, formatDoctorJSON }  :236-236
 function _short(p, cwd)  :37-40
 function _contextFiles(cwd)  :42-49
 function _mcpTargets(cwd)  :51-65
-function _countChangedSince(cwd, srcDirs, config, ctxMtime)  :68-94
-function diagnose(cwd, opts = {}) → { checks: Array<{id,label  :101-180
-function formatDoctor(result)  :216-229
-function formatDoctorJSON(result)  :232-234
+function _countChangedSince(cwd, srcDirs, config, ctxMtime)  :68-94  # Count code files under srcDirs modified after the context wa
+function diagnose(cwd, opts = {}) → { checks: Array<{id,label  :101-178  # Run all diagnostic checks
+function formatDoctor(result)  :216-229  # Human-readable checklist
+function formatDoctorJSON(result)  :232-234  # Machine-readable result
 ```
 
-### src/eval/analyzer.js
+### src/eval/corpus.js
 ```
-module.exports = { analyzeFiles, formatAnalysisTable, formatAnalysisJSON }  :235-235
-function isDockerfile(name)  :49-51
-function getExtractorName(filePath)  :53-59
-function tokenCount(sigs)  :62-64
-function hasCoverage(filePath, cwd)  :70-85
-function loadExtractor(name, cwd)  :91-100
-function analyzeFiles(files, cwd, opts) → object[]  :113-170
-function formatAnalysisTable(stats, showSlow) → string  :179-213
-function formatAnalysisJSON(stats) → object  :221-233
+module.exports = { basenameTokens, queryLeakage, validateTasks, sizeBucket, BUCKET_LIMITS }  :83-83
+function basenameTokens(filePath) → string[]  :31-34  # Stemmed tokens of a file path's basename (extension stripped
+function queryLeakage(query, expectedFiles) → { leaked: string[], clean  :42-51  # Leaked tokens between a query and its expected files' basena
+function validateTasks(tasks) → { results: object[], hard  :59-70  # Validate a task list: every task gets a leakage result; hard
+function sizeBucket(fileCount) → 'small'|'medium'|'large'  :77-81  # Size bucket for a repo by indexed file count
 ```
 
 ### src/eval/llm-ablation.js
 ```
 module.exports = { buildGrounding, scoreAnswer, scoreAnswerDetail, runAblation, aggregateRuns }  :168-168
-function _cleanSig(sig)  :19-21
-function buildGrounding(cwd, opts = {}) → string  :34-70
-function scoreAnswerDetail(answerText, cwd) → { total: number, issues:   :78-85
-function scoreAnswer(answerText, cwd)  :88-90
-function runAblation(tasks, cwd, complete, opts = {}) → { tasks: object[], aggreg  :102-137
-function _stats(nums)  :140-144
-function aggregateRuns(aggregates) → { runs:number, n:number,   :154-166
+function _cleanSig(sig)  :19-21  # Strip a signature's trailing line anchor (` :12-20`) for pro
+function buildGrounding(cwd, opts = {}) → string  :34-70  # Build the SigMap grounding block for a repo — what we prepen
+function scoreAnswerDetail(answerText, cwd) → { total: number, issues:   :78-85  # Score an answer: flagged codebase-fact errors + the issue li
+function scoreAnswer(answerText, cwd)  :88-90  # Count flagged codebase-fact errors in an answer (the §9 metr
+function runAblation(tasks, cwd, complete, opts = {}) → { tasks: object[], aggreg  :102-137  # Run the A/B ablation over a task corpus
+function _stats(nums)  :140-144  # mean/min/max of a number list (0s for an empty list)
+function aggregateRuns(aggregates) → { runs:number, n:number,   :154-166  # Aggregate several `runAblation` passes into a stable estimat
 ```
 
 ### src/eval/runner.js
 ```
-module.exports = { run, rank, loadTasks, buildSigIndex, formatTable, formatMetrics, tokenize }  :256-256
-function buildSigIndex(cwd) → Map<string, string[]>  :40-82
-function rank(query, index, topK = 10) → { file: string, score: nu  :99-105
-function estimateTokens(sigs) → number  :116-119
-function loadTasks(tasksFile) → Array<{id:string, query:s  :132-154
-function run(tasksFile, cwd, opts = {}) → { * tasks: Array<{id, que  :172-219
-function formatTable(taskResults) → string  :230-238
-function formatMetrics(metrics) → string  :245-254
-```
-
-### src/eval/scorer.js
-```
-module.exports = { hitAtK, reciprocalRank, precisionAtK, aggregate, firstRank }  :126-126
-function firstRank(ranked, expected) → number  :22-29
-function normalizePath(p) → string  :38-40
-function hitAtK(ranked, expected, k = 5) → 0|1  :49-51
-function reciprocalRank(ranked, expected) → number  :59-62
-function precisionAtK(ranked, expected, k = 5) → number  :72-78
-function aggregate(results, k = 5) → { * hitAt5: number, // fr  :93-120
-function round(x)  :122-124
-```
-
-### src/eval/usefulness-scorer.js
-```
-module.exports = { scoreUsefulness, computeUsefulnessStats }  :3-3
-function scoreUsefulness(taskResult, rankingScore)  :11-38
-function computeUsefulnessStats(taskResults)  :40-66
+module.exports = { run, rank, loadTasks, buildSigIndex, formatTable, formatMetrics, tokenize }  :226-226
+function buildSigIndex(cwd) → Map<string, string[]>  :40-47  # Read the generated context file and build a simple signature
+function rank(query, index, topK = 10, opts = {}) → { file: string, score: nu  :64-71  # Rank all files in the index against a query with the identif
+function estimateTokens(sigs) → number  :82-85  # Estimate token count from character count (chars/4, ±5%)
+function loadTasks(tasksFile) → Array<{id:string, query:s  :98-121  # Load tasks from a JSONL file
+function run(tasksFile, cwd, opts = {}) → { * tasks: Array<{id, que  :139-189  # Run all tasks in tasksFile against the repo at cwd
+function formatTable(taskResults) → string  :200-208  # Format task results as a markdown table string
+function formatMetrics(metrics) → string  :215-224  # Format aggregate metrics as a human-readable string
 ```
 
 ### src/evidence/pack.js
 ```
 module.exports = { buildEvidencePack, formatJSON, formatMarkdown, parseAnchor, riskLabelFor, riskFactorsFor, findRelatedTests, SCHEMA_VERSION, SCHEMA_URL, TEST_DISCOVERY }  :326-337
-function parseAnchor(sig) → { symbol: string, start:   :64-72
-function riskLabelFor(relPath) → 'generated'|'test'|'migra  :84-86
-function riskFactorsFor(relPath) → string[]  :96-108
-function stemOf(relPath)  :111-114
-function testTargetStem(relPath) → string  :126-132
-function findRelatedTests(relPath, allFiles) → string[]  :143-154
-function reasonFor(signals)  :157-168
-function sigTokens(sigs)  :171-173
-function canonicalize(value) → string  :180-182
+function parseAnchor(sig) → { symbol: string, start:   :64-72  # Split a signature's `  :start-end` line anchor from its symb
+function riskLabelFor(relPath) → 'generated'|'test'|'migra  :84-86  # Classify a file into a risk label (C3, v8
+function riskFactorsFor(relPath) → string[]  :96-108  # Every risk category a file matches, in the same strict prece
+function stemOf(relPath)  :111-114  # Filename stem (basename minus the first extension chain)
+function testTargetStem(relPath) → string  :126-132  # Infer the implementation stem a test file targets, by stripp
+function findRelatedTests(relPath, allFiles) → string[]  :143-154  # Impl→test discovery (C2, v8
+function reasonFor(signals)  :157-168  # Map a ranker `signals` object into a short human-readable re
+function sigTokens(sigs)  :171-173  # Token estimate for a signature block (matches the ranker's h
+function canonicalize(value) → string  :180-182  # Stable stringify with recursively sorted object keys, for ha
 function sortKeys(value)  :184-192
-function buildEvidencePack(query, cwd, opts = {}) → object  :205-281
+function buildEvidencePack(query, cwd, opts = {}) → object  :205-281  # Build an Evidence Pack for a query
 function ranked0Empty(query)  :284-286
-function formatJSON(pack)  :289-291
-function formatMarkdown(pack)  :294-324
+function formatJSON(pack)  :289-291  # Pretty-printed canonical JSON rendering of a pack
+function formatMarkdown(pack)  :294-315  # Markdown handoff rendering of a pack
 ```
 
-### src/extractors/coverage.js
+### src/extractors/csharp.js
 ```
-module.exports = { buildTestIndex, isTested }  :79-79
-function walkFiles(dir)  :6-20
-function buildTestIndex(cwd, testDirs)  :22-62
-function isTested(funcName, testIndex)  :64-77
-```
-
-### src/extractors/cpp.js
-```
-module.exports = { extract }  :69-69
-function extract(src) → string[]  :8-69
-function extractBlock(src, startIndex)  :36-45
-function extractMembers(block)  :47-57
-function normalizeParams(params)  :59-62
-function normalizeType(type)  :64-67
+module.exports = { extract }  :71-71
+function extract(src) → string[]  :12-71  # Extract signatures from C# source code
+function extractBlock(src, startIndex)  :35-44
+function extractMembers(block)  :46-59
+function normalizeParams(params)  :61-64
+function normalizeType(type)  :66-69
 ```
 
-### src/extractors/css.js
+### src/extractors/dart.js
 ```
-module.exports = { extract }  :69-69
-function extract(src) → string[]  :8-17
+module.exports = { extract }  :84-84
+function extract(src) → string[]  :12-84  # Extract signatures from Dart source code
+function extractBlock(src, startIndex)  :54-63
+function extractMembers(block)  :65-77
+function normalizeParams(params)  :79-81
 ```
 
 ### src/extractors/deps.js
 ```
-module.exports = { extractPythonDeps, extractTSDeps, extractRDeps, buildReverseDepMap }  :110-110
-function extractPythonDeps(src) → string[]  :26-41
-function extractTSDeps(src) → string[]  :48-61
-function extractRDeps(src) → string[]  :76-90
-function buildReverseDepMap(forwardMap) → Map<string, string[]>  :97-108
+module.exports  :110-110
+function extractPythonDeps  :26-41
+function extractTSDeps  :48-59
+function extractRDeps  :76-82
+function buildReverseDepMap  :97-108
 ```
 
 ### src/extractors/dispatch.js
 ```
 module.exports = { extractFile, langFor }  :112-112
-function langFor(filePathOrName)  :86-91
-function extractFile(filePathOrName, src) → string[]  :99-110
+function langFor(filePathOrName)  :86-91  # Resolve a language key from a file path/name
+function extractFile(filePathOrName, src) → string[]  :99-110  # Extract signatures from a file's content using the right ext
 ```
 
-### src/extractors/dockerfile.js
+### src/extractors/go.js
 ```
-module.exports = { extract }  :49-49
-function extract(src) → string[]  :8-47
-```
-
-### src/extractors/gdscript.js
-```
-module.exports = { extract }  :131-131
-function extract(src) → string[]  :9-42
-function extractInnerMembers(stripped, startIndex)  :98-114
-function normalizeParams(params)  :116-129
+module.exports = { extract }  :109-109
+function extract(src) → string[]  :12-109  # Extract signatures from Go source code
+function extractBlock(src, startIndex)  :55-64
+function extractInterfaceMethods(block)  :66-78
+function normalizeParams(params)  :80-83
+function buildDocHints(src)  :89-98
+function firstDocSentence(block)  :101-107
 ```
 
-### src/extractors/generic.js
+### src/extractors/java.js
 ```
-module.exports = { extract }  :2-2
-function extract(src)  :14-26
-```
-
-### src/extractors/graphql.js
-```
-module.exports = { extract }  :66-66
-function extract(src) → string[]  :11-66
-```
-
-### src/extractors/html.js
-```
-module.exports = { extract }  :39-39
-function extract(src) → string[]  :9-37
+module.exports = { extract }  :106-106
+function extract(src) → string[]  :12-106  # Extract signatures from Java source code
+function extractBlock(src, startIndex)  :38-48
+function extractMembers(block)  :50-64
+function normalizeParams(params)  :66-69
+function normalizeType(type)  :71-74
+function buildDocHints(src)  :82-95
+function firstDocSentence(body)  :98-104
 ```
 
 ### src/extractors/javascript.js
 ```
-module.exports = { extract }  :147-147
-function extract(src) → string[]  :13-112
-function extractBlock(src, startIndex)  :88-98
-function extractClassMembers(block, returnHints)  :103-124
-function buildReturnHints(src)  :119-121
-function normalizeType(type)  :133-136
-function formatReturnHint(type)  :138-140
-function normalizeParams(params)  :142-145
+module.exports = { extract }  :218-218
+function extract(src) → string[]  :14-95  # Extract signatures from JavaScript source code
+function extractBlock(src, startIndex)  :119-129
+function extractClassMembers(block, maskedBlock, returnHints)  :137-165
+function buildReturnHints(src)  :160-162
+function buildDocHints(src)  :177-193
+function firstDocSentence(body)  :196-202
+function normalizeType(type)  :204-207
+function formatReturnHint(type)  :209-211
+function normalizeParams(params)  :213-216
+```
+
+### src/extractors/kotlin.js
+```
+module.exports = { extract }  :90-90
+function extract(src) → string[]  :12-90  # Extract signatures from Kotlin source code
+function extractBlock(src, startIndex)  :54-63
+function extractMembers(block)  :65-90
+function normalizeParams(params)  :81-88
 ```
 
 ### src/extractors/line-anchor.js
 ```
-module.exports = { lineAt, anchor, withAnchor }  :52-52
-function lineAt(src, idx) → number  :22-29
-function anchor(start, end) → string  :37-39
-function withAnchor(sig, start, end) → string  :48-50
+module.exports  :52-52
+function lineAt  :22-29
+function anchor  :37-39
+function withAnchor  :48-50
 ```
 
-### src/extractors/markdown.js
+### src/extractors/php.js
 ```
-module.exports = { extract }  :30-30
-function extract(src) → string[]  :10-28
-```
-
-### src/extractors/patterns.js
-```
-module.exports = { extract }  :135-135
-function extract(src) → string[]  :10-133
+module.exports = { extract }  :96-96
+function extract(src) → string[]  :12-96  # Extract signatures from PHP source code
+function extractBlock(src, startIndex)  :58-67
+function extractMembers(block)  :69-96
+function normalizeParams(params)  :86-89
+function normalizeType(type)  :91-94
 ```
 
 ### src/extractors/prdiff.js
 ```
 module.exports = { diffSignatures, extractName }  :70-70
-function diffSignatures(baseSigs, currentSigs) → {added:string[], removed:  :9-36
-function extractName(sig)  :47-70
+function diffSignatures(baseSigs, currentSigs) → {added:string[], removed:  :9-36  # Compare signature arrays and produce compact diff markers
+function extractName(sig)  :47-70  # Extract the declared symbol name from a signature line
 ```
 
-### src/extractors/properties.js
+### src/extractors/rust.js
 ```
-module.exports = { extract }  :37-37
-function extract(src) → string[]  :10-35
-```
-
-### src/extractors/protobuf.js
-```
-module.exports = { extract }  :63-63
-function extract(src) → string[]  :10-63
-```
-
-### src/extractors/python_ast.py
-```
-def annotation_to_str(node)  :25-48  # Convert an AST annotation node to a string representation
-def format_args(args_node)  :51-103  # Format a function arguments node into a compact signature st
-def get_decorator_names(node)  :106-120  # Return a list of decorator name strings for a function/class
-def is_dataclass(node)  :123-124
-def is_basemodel(bases)  :127-133  # Check if class bases include BaseModel or BaseSettings
-def is_optional_annotation(annotation)  :136-146  # Check if an annotation represents an Optional type
-def get_docstring_hint(node)  :149-158  # Extract first sentence of docstring, if present
-def extract_dataclass_fields(class_node)  :161-171  # Return a collapsed fields string for a @dataclass class
-def extract_basemodel_fields(class_node)  :174-190  # Return a compact {required*, optional
-def extract_class_constants(class_node)  :193-213  # Yield ALL_CAPS constant assignments from class body
-def extract_method_sig(func_node)  :222-229  # Format a method signature string (already indented by caller
-def extract_function_sig(func_node, src_lines)  :232-241  # Format a top-level function signature string
-def extract_fastapi_routes(tree, src_lines)  :244-265  # Extract FastAPI route signatures from top-level decorated fu
-def extract(filepath)  :268-338
-def main()  :341-351
+module.exports = { extract }  :138-138
+function extract(src) → string[]  :12-116  # Extract signatures from Rust source code
+function extractBlock(src, startIndex)  :76-85
+function extractMethods(block)  :87-138
+function normalizeParams(params)  :102-105
+function extractReturnType(afterParen)  :107-138
+function buildDocHints(src)  :119-127
+function firstDocSentence(block)  :130-136
 ```
 
-### src/extractors/python_dataclass.js
+### src/extractors/scala.js
 ```
-module.exports = { extract }  :77-77
-function extract(src) → string[]  :10-75
-```
-
-### src/extractors/python.js
-```
-module.exports = { extract, tryNativeExtract }  :262-262
-function pyBlockEnd(srcLines, startLine) → number  :14-24
-function tryNativeExtract(filePath) → string[]|null  :32-44
-function extract(src, filePath) → string[]  :55-140
-function extractClassMethods(stripped, startIndex)  :142-161
-function tryExtractDataclassFields(stripped, classIndex)  :163-177
-function tryExtractBaseModelFields(stripped, bodyStart)  :179-194
-function extractClassConstants(stripped, startIndex)  :196-210
-function extractReturnType(sigLine)  :212-218
-function normalizeParams(params)  :220-238
-function extractDocHint(src, fnName, fnSigLine)  :240-260
+module.exports = { extract }  :88-88
+function extract(src) → string[]  :12-88  # Extract signatures from Scala source code
+function extractBlock(src, startIndex)  :47-56
+function extractMembers(block)  :58-88
+function normalizeParams(params)  :74-81
+function normalizeType(type)  :83-86
 ```
 
-### src/extractors/r.js
+### src/extractors/scan.js
 ```
-module.exports = { extract }  :273-273
-function extract(src) → string[]  :20-117
-function collectRoxygenHints(src)  :125-153
-function pickRoxygenLine(block, tag)  :155-169
-function applyHint(hints, name)  :171-174
-function extractListMethods(body, cap)  :180-193
-function inAnyRange(pos, ranges)  :195-200
-function readFirstStringArg(body)  :203-206
-function readBalancedParens(src, openIdx, cap = 16384)  :214-237
-function normalizeParams(raw)  :244-271
+module.exports = { stripComments, maskCode, readBalanced }  :91-91
+function stripComments(src) → string  :23-39  # Blank comments only — string-aware, so `//` or `/*` INSIDE a
+function maskCode(src) → string  :47-63  # Blank comments AND string/template contents (quotes included
+function readBalanced(masked, openIdx, open = '(', close = ')', cap = 4000) → number  :76-89  # Index of the delimiter that closes the one open at `openIdx`
 ```
 
-### src/extractors/ruby.js
+### src/extractors/swift.js
 ```
-module.exports = { extract }  :54-54
-function extract(src) → string[]  :8-38
-function normalizeParams(params)  :40-43
-function extractReturnHint(stripped, index)  :45-52
-```
-
-### src/extractors/shell.js
-```
-module.exports = { extract }  :43-43
-function extract(src) → string[]  :8-43
-```
-
-### src/extractors/sql.js
-```
-module.exports = { extract }  :93-93
-function extract(src) → string[]  :10-78
-function _cleanName(raw)  :80-82
-function _normalizeParams(raw)  :84-91
-```
-
-### src/extractors/svelte.js
-```
-module.exports = { extract }  :58-58
-function extract(src) → string[]  :8-58
-function normalizeParams(params)  :48-51
-function normalizeType(type)  :53-56
-```
-
-### src/extractors/terraform.js
-```
-module.exports = { extract }  :74-74
-function extract(src) → string[]  :11-74
-```
-
-### src/extractors/todos.js
-```
-module.exports = { extractTodos }  :26-26
-function extractTodos(src) → {line:number, tag:string,  :8-24
-```
-
-### src/extractors/toml.js
-```
-module.exports = { extract }  :42-42
-function extract(src) → string[]  :10-40
-```
-
-### src/extractors/typescript_react.js
-```
-module.exports = { extract }  :60-60
-function extract(src) → string[]  :10-20
+module.exports = { extract }  :97-97
+function extract(src) → string[]  :12-97  # Extract signatures from Swift source code
+function extractBlock(src, startIndex)  :54-63
+function extractMembers(block)  :65-97
+function normalizeParams(params)  :80-87
+function extractArrowType(str)  :89-97
 ```
 
 ### src/extractors/typescript.js
 ```
-module.exports = { extract }  :221-221
-function extract(src) → string[]  :13-118
-function extractBlock(src, startIndex)  :160-170
-function extractInterfaceMembers(block)  :174-188
-function extractClassMembers(block)  :195-221
-function normalizeParams(params)  :216-219
-```
-
-### src/extractors/vue_sfc.js
-```
-module.exports = { extract }  :99-99
-function extract(src) → string[]  :10-68
-```
-
-### src/extractors/vue.js
-```
-module.exports = { extract }  :80-80
-function extract(src) → string[]  :8-35
-function normalizeParams(params)  :70-73
-function normalizeType(type)  :75-78
-```
-
-### src/extractors/xml.js
-```
-module.exports = { extract }  :46-46
-function extract(src) → string[]  :10-44
-```
-
-### src/extractors/yaml.js
-```
-module.exports = { extract }  :59-59
-function extract(src) → string[]  :8-57
-```
-
-### src/format/benchmark-report.js
-```
-module.exports = { loadBenchmarkReports, buildBenchmarkSummary, generateBenchmarkReportHtml, writeBenchmarkReport }  :438-443
-function escapeHtml(value)  :6-12
-function formatInt(value)  :14-18
-function formatCompact(value)  :20-26
-function formatPct(value, digits = 1)  :28-32
-function formatMaybePct(value, digits = 1)  :34-38
-function formatRatio(value, digits = 1)  :40-44
-function formatMoney(value)  :46-50
-function durationLabel(ms)  :52-60
-function maxOrZero(values)  :62-65
-function readJson(filePath)  :67-74
-function loadBenchmarkReports(cwd)  :76-86
-function buildRetrievalSummary(retrieval)  :88-123
-function buildBenchmarkSummary(reports, matrixSummary)  :125-159
-function renderCard(label, value, hint, tone)  :161-170
-function renderProgress(label, value, max, suffix)  :172-185
-function renderMatrixSection(matrix)  :187-211
-function renderTokenSection(token)  :213-239
-function renderRetrievalSection(retrieval)  :241-268
-function renderQualitySection(quality)  :270-296
-function renderTaskSection(task)  :298-327
-function generateBenchmarkReportHtml(reports, opts = {})  :329-388
-function writeBenchmarkReport(cwd, opts = {})  :426-436
-```
-
-### src/format/cache.js
-```
-module.exports = { formatCache, formatCachePayload }  :53-53
-function formatCache(content) → string  :19-27
-function formatCachePayload(content, model) → string  :37-51
+module.exports = { extract }  :326-326
+function extract(src) → string[]  :14-98  # Extract signatures from TypeScript source code
+function extractBlock(src, startIndex)  :195-205
+function extractInterfaceMembers(block)  :209-227
+function extractClassMembers(block, maskedBlock)  :234-318
+function normalizeParams(params)  :264-294
+function buildDocHints(src)  :299-315
+function firstDocSentence(body)  :318-324
 ```
 
 ### src/format/dashboard.js
@@ -886,17 +604,10 @@ function fmtDuration(ms)  :45-51
 function fmtPct(p)  :53-55
 function colorPct(p, text)  :57-61
 function pad(s, w, align)  :63-68
-function bar(pct, width)  :71-76
-function impactBar(sharePct, width)  :79-82
-function renderSummary(agg, opts = {}) → string  :94-153
-function renderBreakdown(agg) → string  :160-199
-```
-
-### src/format/llm-txt.js
-```
-module.exports = { format, outputPath }  :3-3
-function outputPath(cwd)  :5-5
-function format(context, cwd, version)  :7-28
+function bar(pct, width)  :71-76  # Solid horizontal efficiency bar with a dotted remainder
+function impactBar(sharePct, width)  :79-82  # Proportional impact bar (share of total saved)
+function renderSummary(agg, opts = {}) → string  :94-153  # Render the global summary + by-operation table
+function renderBreakdown(agg) → string  :160-199  # Render daily / weekly / monthly trend tables
 ```
 
 ### src/format/llms-txt.js
@@ -911,17 +622,17 @@ function format(context, cwd, writtenFiles, sigmapVersion)  :21-69
 ### src/format/terse.js
 ```
 module.exports = { encodeTerseSig, encodeTerseSigs, measureTerse, splitAnchor }  :86-86
-function splitAnchor(sig) → { text: string, suffix: s  :25-30
-function encodeTerseSig(sig) → string  :37-50
-function encodeTerseSigs(sigs) → string[]  :57-59
-function _tokens(sigs)  :62-64
-function measureTerse(sigsList) → { beforeTokens: number, a  :72-84
+function splitAnchor(sig) → { text: string, suffix: s  :25-30  # Split a signature into the compactable text and the byte-pre
+function encodeTerseSig(sig) → string  :37-50  # Compact one signature line
+function encodeTerseSigs(sigs) → string[]  :57-59  # Compact an array of signature lines
+function _tokens(sigs)  :62-64  # Estimated tokens of joined signature lines (same chars/4 rul
+function measureTerse(sigsList) → { beforeTokens: number, a  :72-84  # Measure the real reduction terse encoding buys over a set of
 ```
 
 ### src/format/usage-guidance.js
 ```
 module.exports = { usageBlock }  :28-28
-function usageBlock()  :12-26
+function usageBlock()  :12-26  # Canonical "how to use SigMap" guidance block (v6
 ```
 
 ### src/format/verify-report.js
@@ -930,8 +641,8 @@ module.exports = { renderReportHtml, renderReportMarkdown, escapeHtml }  :164-16
 function escapeHtml(value)  :23-29
 function toneFor(issue)  :31-35
 function labelFor(issue)  :37-39
-function renderReportHtml(result, opts = {}) → string  :48-115
-function renderReportMarkdown(result)  :144-162
+function renderReportHtml(result, opts = {}) → string  :48-115  # Render the verify result to a full HTML document
+function renderReportMarkdown(result)  :144-162  # Compact Markdown rendering of the same result (CI / PR comme
 ```
 
 ### src/graph/blast-radius.js
@@ -940,81 +651,77 @@ module.exports = { methodBlastRadius, tierFor, DIRECT_WEIGHT, TRANSITIVE_WEIGHT 
 function tierFor(score)  :25-31
 function _normRel(p)  :33-35
 function _bfs(seedIds, reverse, maxDepth)  :38-60
-function methodBlastRadius(changedFiles, cwd, opts = {}) → { * available: boolean, *  :78-130
-```
-
-### src/graph/builder.js
-```
-module.exports = { build, buildFromCwd, extractFileDeps, normalizePath, loadAliasMap, resolveAlias }  :494-494
-function normalizePath(p)  :17-19
-function probeJs(base, fileSet) → string|null  :40-53
-function resolveJsPath(dir, importStr, fileSet) → string|null  :62-64
-function stripJsonc(src)  :70-84
-function loadAliasMap(cwd) → { baseUrl: string|null, e  :96-117
-function resolveAlias(spec, aliasMap, fileSet) → string|null  :126-150
-function escapeRegex(s)  :157-159
-function resolveRPath(dir, importStr, fileSet, cwd)  :161-176
-function extractFileDeps(filePath, content, fileSet, cwd, ctx) → string[]  :190-330
-function build(files, cwd, ctx) → { forward: Map<string,str  :387-426
-function buildFromCwd(cwd, opts) → { forward: Map<string,str  :438-492
+function methodBlastRadius(changedFiles, cwd, opts = {}) → { * available: boolean, *  :78-130  # Score the method-level blast radius of a changed-file list
 ```
 
 ### src/graph/call-graph.js
 ```
-module.exports = { buildCallGraph, buildCallFileGraph, methodImpact, methodCallees, formatCallGraph, formatCallGraphJSON, extractDefs, maskJs, maskPy, maskRust }  :563-567
-function normalizePath(p)  :41-41
-function toRel(cwd, f)  :42-42
-function symId(cwd, absFile, name)  :43-43
-function maskJs(src)  :49-65
-function maskRust(src)  :70-91
-function maskPy(src)  :93-110
-function matchDelim(masked, openIdx, open, close)  :113-120
-function lineAt(src, idx)  :122-127
-function jsDefs(masked)  :132-237
-function pyDefs(masked)  :200-220
-function goDefs(masked)  :224-344
-function javaDefs(masked)  :250-367
-function rustDefs(masked)  :278-401
-function maskFor(filePath, src)  :300-305
-function extractDefs(filePath, src)  :307-315
-function callsInRange(masked, start, end)  :318-330
-function _walk(dir, excludeSet, out, depth)  :334-347
-function buildCallGraph(cwd, opts = {}) → { * forward: Map<string,s  :363-446
-function buildCallFileGraph(cwd, opts = {}) → { forward: Map<string,str  :459-482
-function _resolveSymbol(symbol, defs)  :485-490
-function _bfs(seedIds, graph, maxDepth)  :493-506
-function methodImpact(symbol, cwd, opts = {}) → { symbol:string, resolved  :516-522
-function methodCallees(symbol, cwd, opts = {}) → { symbol:string, resolved  :528-534
-function formatCallGraph(result, kind)  :537-549
+module.exports = { buildCallGraph, buildCallFileGraph, methodImpact, methodCallees, formatCallGraph, formatCallGraphJSON, extractDefs, maskJs, maskPy, maskRust }  :567-571
+function normalizePath(p)  :42-42
+function toRel(cwd, f)  :43-43
+function symId(cwd, absFile, name)  :44-44
+function maskJs(src)  :50-66
+function maskRust(src)  :71-92
+function maskPy(src)  :94-111
+function matchDelim(masked, openIdx, open, close)  :114-121
+function lineAt(src, idx)  :123-128
+function jsDefs(masked)  :133-199
+function pyDefs(masked)  :201-221
+function goDefs(masked)  :225-246
+function javaDefs(masked)  :251-274
+function rustDefs(masked)  :279-297
+function maskFor(filePath, src)  :301-306
+function extractDefs(filePath, src)  :308-316
+function callsInRange(masked, start, end)  :319-331
+function _walk(dir, excludeSet, out, depth)  :335-348
+function buildCallGraph(cwd, opts = {}) → { * forward: Map<string,s  :364-447  # Build the method-level call-graph for a project
+function buildCallFileGraph(cwd, opts = {}) → { forward: Map<string,str  :460-486  # Collapse the symbol-level call-graph to FILE-level bidirecti
+function _resolveSymbol(symbol, defs)  :489-494
+function _bfs(seedIds, graph, maxDepth)  :497-510
+function methodImpact(symbol, cwd, opts = {}) → { symbol:string, resolved  :520-526  # Method-level blast radius: everything that (transitively) ca
+function methodCallees(symbol, cwd, opts = {}) → { symbol:string, resolved  :532-538  # What `symbol` (transitively) calls
+function formatCallGraph(result, kind)  :541-553
 … +1 more signatures
+```
+
+### src/graph/centrality.js
+```
+module.exports = { computeCentrality, DAMPING, ITERATIONS }  :61-61
+function computeCentrality(graph) → Map<string, number>  :27-59  # Compute a normalized centrality score for every file in a de
 ```
 
 ### src/graph/impact.js
 ```
 module.exports = { getImpact, analyzeImpact, formatImpact, formatImpactJSON }  :240-240
 function normalizePath(p)  :16-18
-function bfs(startFile, reverseGraph, maxDepth) → { direct: Set<string>, tr  :33-70
+function bfs(startFile, reverseGraph, maxDepth) → { direct: Set<string>, tr  :33-70  # Walk the reverse graph from `startFile` using BFS up to `max
 function isTestFile(f)  :92-92
 function isRouteFile(f)  :93-93
-function getImpact(changedFile, graph, opts) → { * changed: string, * di  :116-142
-function analyzeImpact(changedFiles, cwd, opts) → { file: string, impact: o  :156-171
-function formatImpact(result) → string  :183-221
-function formatImpactJSON(result) → object  :229-238
+function getImpact(changedFile, graph, opts) → { * changed: string, * di  :116-142  # Compute the impact of changing `changedFile`
+function analyzeImpact(changedFiles, cwd, opts) → { file: string, impact: o  :156-171  # Analyse the impact of one or more changed files, building th
+function formatImpact(result) → string  :183-221  # Format an impact result as a readable markdown string
+function formatImpactJSON(result) → object  :229-238  # Format an impact result as a JSON-serialisable object
+```
+
+### src/graph/path-key.js
+```
+module.exports = { graphKey }  :26-26
+function graphKey(p)  :22-24  # Canonical key for a filesystem path used as a graph node
 ```
 
 ### src/health/scorer.js
 ```
 module.exports = { score, composeHealth }  :227-227
 function gradeFor(points)  :52-57
-function composeHealth(s) → object  :66-117
-function score(cwd)  :123-225
+function composeHealth(s) → object  :66-117  # Pure scoring core
+function score(cwd)  :123-225  # Gather health signals from disk and score them
 ```
 
 ### src/init/creation-workflow.js
 ```
 module.exports = { renderCreationWorkflowBlock, injectCreationWorkflow, START, END }  :59-59
-function renderCreationWorkflowBlock()  :18-35
-function injectCreationWorkflow(existing, block) → string  :45-57
+function renderCreationWorkflowBlock()  :18-35  # Render the Creation workflow block (including its start/end 
+function injectCreationWorkflow(existing, block) → string  :45-57  # Inject (or replace) the Creation workflow block in existing 
 ```
 
 ### src/judge/judge-engine.js
@@ -1022,26 +729,9 @@ function injectCreationWorkflow(existing, block) → string  :45-57
 module.exports = { groundedness, claimGrounding, judge }  :182-182
 function tokenize(text)  :15-17
 function groundedness(response, context)  :19-27
-function claimGrounding(response, context) → { total: number, grounded  :48-78
+function claimGrounding(response, context) → { total: number, grounded  :48-78  # Claim-level grounding (v8
 function extractContextFiles(context, cwd)  :89-111
 function judge(response, context, opts = {})  :113-180
-```
-
-### src/learning/weights.js
-```
-module.exports = { BASELINE, DECAY, MAX_MULT, MIN_MULT, weightsPath, clampMultiplier, normalizeFile, loadWeights, saveWeights, updateWeights, boostFiles, penalizeFiles, resetWeights, exportWeights, importWeights }  :154-170
-function weightsPath(cwd)  :11-13
-function clampMultiplier(value)  :15-20
-function normalizeFile(cwd, filePath)  :22-31
-function sanitizeWeights(cwd, weights)  :33-46
-function loadWeights(cwd)  :48-55
-function saveWeights(cwd, weights)  :57-76
-function updateWeights(cwd, opts = {})  :78-109
-function boostFiles(cwd, files, amount = 0.15)  :111-113
-function penalizeFiles(cwd, files, amount = 0.10)  :115-117
-function resetWeights(cwd)  :119-122
-function exportWeights(cwd, outputPath)  :124-134
-function importWeights(cwd, importPath, replace)  :136-152
 ```
 
 ### src/map/build-ci.js
@@ -1052,12 +742,6 @@ function npmScripts(cwd, rows)  :24-30
 function ciWorkflows(cwd, rows)  :32-56
 function makeTargets(cwd, rows)  :58-69
 function analyze(files, cwd)  :71-89
-```
-
-### src/map/class-hierarchy.js
-```
-module.exports = { analyze }  :117-117
-function analyze(files, cwd)  :16-117
 ```
 
 ### src/map/config-manifest.js
@@ -1074,19 +758,9 @@ function analyze(files, cwd)  :83-99
 ### src/map/env-schema.js
 ```
 module.exports = { analyze }  :90-90
-function collectMatches(re, content, into)  :30-37
-function readExampleKeys(cwd)  :39-52
-function analyze(files, cwd)  :54-88
-```
-
-### src/map/import-graph.js
-```
-module.exports = { analyze, extractImports, buildReverseGraph, resolveJsPath, detectCycles }  :185-185
-function extractImports(filePath, content, fileSet)  :22-76
-function resolveJsPath(dir, importStr, fileSet)  :78-95
-function detectCycles(graph)  :100-126
-function buildReverseGraph(graph)  :131-140
-function analyze(files, cwd)  :145-183
+function collectMatches(re, content, into)  :30-82
+function readExampleKeys(cwd)  :39-82
+function analyze(files, cwd)  :54-82
 ```
 
 ### src/map/migrations.js
@@ -1096,21 +770,58 @@ function walk(dir, cwd, depth, out)  :31-62
 function analyze(files, cwd)  :64-82
 ```
 
+### src/map/route-table.js
+```
+module.exports = { analyze, collectRoutes }  :139-139
+function shouldSkipFile(rel)  :18-21
+function collectRoutes(files, cwd) → string  :30-127  # Structured route rows across the supported frameworks — the 
+function analyze(files, cwd)  :125-137
+```
+
+### src/mcp/handlers.js
+```
+module.exports = { readContext, searchSignatures, getMap, createCheckpoint, getRouting, explainFile, listModules, queryContext, getMethodImpact, getImpact, getLines, readMemory, getCalleeSignatures, notifyFileCreated, notifySymbolAdded, notifyFileDeleted, getDiffContext, getArchitectureOverview, verifySuggestion, squeezeOutput, getBudget }  :1017-1017
+function _readContextFiles(cwd)  :10-17
+function readContext(args, cwd)  :36-66  # read_context({ module
+function searchSignatures(args, cwd)  :74-100  # search_signatures({ query }) → string
+function getMap(args, cwd)  :108-131  # get_map({ type }) → string
+function createCheckpoint(args, cwd)  :143-215  # create_checkpoint({ note
+function getRouting(args, cwd)  :224-261  # get_routing({}) → string
+function explainFile(args, cwd)  :269-356  # explain_file({ path }) → string
+function listModules(args, cwd)  :364-403  # list_modules({}) → string
+function queryContext(args, cwd)  :411-445  # query_context({ query, topK
+function getMethodImpact(args, cwd)  :453-467  # get_method_impact({ symbol, direction
+function getImpact(args, cwd)  :475-487  # get_impact({ file, depth
+function getLines(args, cwd)  :496-544  # get_lines({ file, start, end }) → string
+function readMemory(args, cwd)  :552-587  # read_memory({ limit
+function getBudget(args, cwd)  :596-622  # get_budget({ session
+function getCalleeSignatures(args, cwd)  :631-676  # get_callee_signatures — return the exact defining signature(
+function _pkgVersion(cwd)  :683-686
+function notifyFileCreated(args, cwd)  :690-712  # notify_file_created — extract a file's signatures and index 
+function notifySymbolAdded(args, cwd)  :715-735  # notify_symbol_added — append one signature to a file's live 
+function notifyFileDeleted(args, cwd)  :738-752  # notify_file_deleted — drop a file's cache-overlay entry
+function _changedFiles(cwd, args)  :758-770  # List the files changed in the working tree, staged area, or 
+function getDiffContext(args, cwd)  :779-850  # get_diff_context({ base
+function getArchitectureOverview(args, cwd)  :859-927  # get_architecture_overview({}) → string
+function verifySuggestion(args, cwd)  :937-972  # verify_suggestion({ code }) → string
+function squeezeOutput(args, cwd)  :982-1015  # squeeze_output({ content }) → string
+```
+
 ### src/mcp/install.js
 ```
 module.exports = { CLIENTS, listClients, installClient, resolveTarget }  :142-142
-function resolveTarget(spec, cwd, home, useGlobal)  :39-45
-function listClients(opts = {})  :48-62
+function resolveTarget(spec, cwd, home, useGlobal)  :39-45  # Resolve the absolute config path for a client, honoring `glo
+function listClients(opts = {})  :48-62  # List supported clients with their resolved target paths
 function serverArgs(scriptPath)  :64-66
-function _installJson(filePath, scriptPath)  :69-81
-function _installZed(filePath, scriptPath)  :84-96
-function _installYaml(filePath, scriptPath)  :99-117
-function installClient(client, opts = {}) → client, label, path, stat  :124-140
+function _installJson(filePath, scriptPath)  :69-81  # Install into a JSON `mcpServers` config (create file/dir if 
+function _installZed(filePath, scriptPath)  :84-96  # Install into Zed's `context_servers` config (create file/dir
+function _installYaml(filePath, scriptPath)  :99-117  # Install into Codex CLI YAML (append block; create file if ab
+function installClient(client, opts = {}) → client, label, path, stat  :124-140  # Install the sigmap MCP server for a single client
 ```
 
 ### src/mcp/tools.js
 ```
-module.exports = { TOOLS }  :392-392
+module.exports = { TOOLS }  :418-418
 ```
 
 ### src/nudge.js
@@ -1121,7 +832,7 @@ function defaultUsage()  :20-25
 function readUsage(cwd)  :27-30
 function writeUsageAtomic(cwd, usage)  :32-38
 function showStarNudge(write)  :52-54
-function checkStarNudge(cwd, runSuccess, opts = {}) → { usage, nudged  :67-90
+function checkStarNudge(cwd, runSuccess, opts = {}) → { usage, nudged  :67-90  # Record one run and, when the thresholds are first met, show 
 ```
 
 ### src/plan/planner.js
@@ -1133,48 +844,48 @@ function createPlan(goal, cwd, config = {})  :12-94
 ### src/plan/verify-plan.js
 ```
 module.exports = { verifyPlan, DEFAULT_BLAST_THRESHOLD, DEFAULT_SCOPE_THRESHOLD }  :108-108
-function _fileExists(cwd, ref)  :24-30
-function verifyPlan(planText, cwd, opts = {}) → { issues: object[], blast  :42-106
+function _fileExists(cwd, ref)  :24-30  # Resolve a referenced path against cwd (handles a leading "
+function verifyPlan(planText, cwd, opts = {}) → { issues: object[], blast  :42-106  # Verify a plan against the live index
 ```
 
 ### src/retrieval/bm25.js
 ```
-module.exports = { tokenize, stem, bm25rank, PATH_BOOST, STOP, expandQuery, EXPANSIONS, EXPANSION_WEIGHT }  :195-195
-function stem(w) → string  :36-45
-function tokenize(text) → string[]  :54-65
-function expandQuery(qToks) → Map<string, number>  :132-141
-function bm25rank(query, candidates) → Array<object & { score: n  :154-193
+module.exports = { tokenize, stem, bm25rank, PATH_BOOST, STOP, expandQuery, EXPANSIONS, EXPANSION_WEIGHT, DOC_WEIGHT, MODULE_DOC_RE, stripAnchor }  :248-248
+function stem(w) → string  :36-45  # Light suffix stemmer — conservative, tuned for code identifi
+function tokenize(text) → string[]  :54-65  # Split on non-alphanumeric characters AND camelCase / snake_c
+function stripAnchor(line)  :126-128
+function expandQuery(qToks) → Map<string, number>  :159-168  # Expand stemmed query tokens with curated synonyms
+function bm25rank(query, candidates, opts) → Array<object & { score: n  :181-246  # BM25 re-rank of candidates against a query
 ```
 
-### src/retrieval/ranker.js
+### src/retrieval/enrich-from-maps.js
 ```
-module.exports = { rank, buildSigIndex, scoreFile, formatRankTable, formatRankJSON, DEFAULT_WEIGHTS, GRAPH_BOOST_AMOUNTS, detectIntent }  :598-598
-function _computePenalty(filePath)  :63-70
-function _computeHubs(graph)  :73-84
-function _isHub(filePath)  :87-91
-function scoreFile(filePath, sigs, queryTokens, weights) → { score: number, signals:  :102-159
-function rank(query, sigIndex, opts) → { file: string, score: nu  :177-302
-function _parseContextFile(contextPath) → Map<string, string[]>  :372-404
-function _mergeSigIndex(target, source)  :407-415
-function _buildSigIndexFromCache(cwd) → Map<string, string[]>  :422-442
-function _enrichSigIndexFromStrategy(cwd, index) → Map<string, string[]>  :450-456
-function buildSigIndex(cwd, opts) → Map<string, string[]>  :473-506
-function formatRankTable(results, query) → string  :515-551
-function formatRankJSON(results, query) → object  :560-575
-function detectIntent(query)  :590-596
+module.exports = { enrichWithSurfaces }  :55-55
+function enrichWithSurfaces(index, cwd) → number  :25-53  # Enrich a signature index with route pseudo-signatures
 ```
 
-### src/retrieval/tokenizer.js
+### src/retrieval/module-doc.js
 ```
-module.exports = { tokenize, STOP_WORDS }  :54-54
-function tokenize(text, opts) → string[]  :31-52
+module.exports = { extractModuleDoc, moduleDocSig, MAX_CHARS }  :120-120
+function _extOf(filePath)  :33-36
+function _cleanLine(line)  :39-120  # Strip comment furniture, JSDoc tags, and markup from one raw
+function extractModuleDoc(src, filePath) → string  :55-117  # Extract a module's leading documentation prose
+function moduleDocSig(src, filePath)  :115-117  # Render as an index-only pseudo-signature, or '' when there i
+```
+
+### src/retrieval/sig-index-store.js
+```
+module.exports = { writeFullIndex, readFullIndex, indexPath, SCHEMA, INDEX_FILE }  :95-95
+function indexPath(cwd)  :34-36  # Absolute path to the retrieval index artifact
+function writeFullIndex(cwd, fileEntries, opts = {}) → { path: string, files: nu  :47-70  # Persist the complete signature index
+function readFullIndex(cwd) → Map<string, string[]>  :83-93  # Load the complete signature index, or an empty Map when abse
 ```
 
 ### src/review/pr-evidence.js
 ```
 module.exports = { buildPrEvidence, formatPrEvidenceMarkdown }  :157-157
-function buildPrEvidence(changedFiles, cwd, opts = {}) → { scope:string, files:obj  :31-84
-function formatPrEvidenceMarkdown(evidence, opts = {})  :89-155
+function buildPrEvidence(changedFiles, cwd, opts = {}) → { scope:string, files:obj  :31-84  # Build the structured PR evidence for a changed-file list
+function formatPrEvidenceMarkdown(evidence, opts = {})  :89-155  # Render the branded, deterministic "PR Evidence Report" Markd
 ```
 
 ### src/review/review-pr.js
@@ -1182,57 +893,38 @@ function formatPrEvidenceMarkdown(evidence, opts = {})  :89-155
 module.exports = { reviewPr, SECURITY_PATTERNS, GOD_NODE_THRESHOLD, SCOPE_DIR_THRESHOLD }  :150-150
 function isTestFile(p)  :32-34
 function isSource(p)  :35-37
-function reviewPr(changedFiles, cwd, opts = {}) → { findings: object[], bla  :48-148
-```
-
-### src/routing/classifier.js
-```
-module.exports = { classify, classifyAll }  :102-102
-function classify(filePath, sigs) → 'fast'|'balanced'|'powerf  :15-83
-function classifyAll(fileEntries, cwd) → { fast: string[], balance  :92-100
-```
-
-### src/routing/hints.js
-```
-module.exports = { TIERS, formatRoutingSection }  :103-103
-function formatRoutingSection(groups) → string  :66-101
+function reviewPr(changedFiles, cwd, opts = {}) → { findings: object[], bla  :48-134  # Audit a changed-file list
 ```
 
 ### src/scaffold/persist.js
 ```
 module.exports = { scaffoldPath, renderScaffoldMarkdown }  :45-45
-function scaffoldPath(cwd)  :15-17
-function renderScaffoldMarkdown(decision, opts = {}) → string  :26-43
+function scaffoldPath(cwd)  :15-17  # Path to the persisted scaffold record
+function renderScaffoldMarkdown(decision, opts = {}) → string  :26-43  # Render an accepted scaffold decision to a markdown record
 ```
 
 ### src/scaffold/propose.js
 ```
 module.exports = { proposeScaffold, DEFAULT_THRESHOLD, HARD_FLOOR }  :112-112
-function _tier(pct)  :21-25
-function _stem(name)  :28-34
-function _testFile(styledStem, framework, ext)  :37-42
-function proposeScaffold(name, conventions, opts = {}) → { ok:boolean, refused:boo  :57-110
+function _tier(pct)  :21-25  # Tier for a consistency score (matches the conventions tiers)
+function _stem(name)  :28-34  # Strip any extension/compound suffix from a requested name → 
+function _testFile(styledStem, framework, ext)  :37-42  # Test file path for a styled stem given the detected framewor
+function proposeScaffold(name, conventions, opts = {}) → { ok:boolean, refused:boo  :57-110  # Propose a convention-matched scaffold, gated by a confidence
 ```
 
-### src/security/patterns.js
+### src/security/redact.js
 ```
-module.exports = { PATTERNS }  :51-51
-```
-
-### src/security/scanner.js
-```
-module.exports = { scan }  :36-36
-function scan(signatures, filePath) → { safe: string[], redacte  :14-34
+module.exports = { redactText }  :56-56
+function redactText(text) → { * text: string, redacte  :30-54  # Redact secrets in arbitrary text
 ```
 
-### src/session/memory.js
+### src/session/memory-inspect.js
 ```
-module.exports = { loadSession, saveSession, mergeSessionContext, clearSession }  :6-6
-function sessionPath(cwd)  :10-12
-function loadSession(cwd)  :14-24
-function saveSession(cwd, { intent, topFiles, query })  :26-35
-function mergeSessionContext(scores, session, currentIntent)  :40-51
-function clearSession(cwd)  :53-56
+module.exports = { inspectMemory, clearMemory, STORES, CLEARABLE }  :86-86
+function storePath(cwd, name)  :25-27
+function countEntries(kind, filePath)  :29-42
+function inspectMemory(cwd) → Array<{store:string, path  :49-64  # Describe every cross-session store
+function clearMemory(cwd, store) → string[]  :72-84  # Delete one clearable store (or 'all' clearable stores)
 ```
 
 ### src/session/notes.js
@@ -1240,16 +932,29 @@ function clearSession(cwd)  :53-56
 module.exports = { notesPath, addNote, readNotes, formatNotes, clearNotes }  :93-93
 function notesPath(cwd)  :23-25
 function _currentBranch(cwd)  :27-29
-function addNote(cwd, text, opts = {})  :39-52
-function readNotes(cwd, limit = 0) → object[]  :60-72
-function formatNotes(notes)  :75-85
-function clearNotes(cwd)  :88-91
+function addNote(cwd, text, opts = {})  :39-52  # Append a note
+function readNotes(cwd, limit = 0) → object[]  :60-72  # Read notes in chronological order (oldest first)
+function formatNotes(notes)  :75-85  # Format notes as a Markdown list (pass already-ordered notes)
+function clearNotes(cwd)  :88-91  # Delete the notes log
+```
+
+### src/skills/skills.js
+```
+module.exports = { SKILLS, SKILL_CLIENTS, renderSkill, renderAgentsBlock, injectSkillsBlock, installSkills, listSkillClients, clientPresent, START, END }  :182-182
+function _footer(version)  :66-69
+function renderSkill(client, skillName, version)  :72-85  # Render one skill's client-specific file content
+function renderAgentsBlock(version)  :88-95  # Render the combined AGENTS
+function injectSkillsBlock(existing, block)  :103-118  # Inject (or replace) the skills block in AGENTS
+function _writeIfChanged(filePath, content)  :120-130
+function installSkills(client, opts = {}) → { client, label, results:  :137-159  # Install both skills for one client
+function clientPresent(client, cwd)  :162-165  # True when the client's parent artifact exists (plain-install
+function listSkillClients(opts = {})  :168-180  # List clients with target paths, presence, and installed stat
 ```
 
 ### src/squeeze/cilog.js
 ```
 module.exports = { squeezeCiLog, stripTimestamp, ERROR_RE }  :71-71
-function stripTimestamp(line)  :17-19
+function stripTimestamp(line)  :17-19  # Remove a leading timestamp prefix from a single line
 function squeezeCiLog(input, opts = {}) → { squeezed: string, kept:  :27-69
 ```
 
@@ -1259,7 +964,7 @@ module.exports = { classify, countFrames }  :115-115
 function countFrames(lines)  :32-38
 function matchesStackTrace(input, lines)  :40-50
 function matchesCiLog(input, lines)  :55-74
-function matchesJsonPayload(input)  :76-93
+function matchesJsonPayload(input)  :76-115
 function classify(input) → { category: 'stacktrace'|  :99-113
 ```
 
@@ -1268,8 +973,8 @@ function classify(input) → { category: 'stacktrace'|  :99-113
 module.exports = { squeeze, shouldPrompt, formatSummary, estimateTokens }  :69-69
 function estimateTokens(s)  :17-17
 function squeeze(input, opts = {}) → { category, confidence, o  :24-49
-function shouldPrompt(reduction, threshold)  :52-55
-function formatSummary(result)  :58-67
+function shouldPrompt(reduction, threshold)  :52-55  # True when the reduction clears the threshold (accepts 0–1 or
+function formatSummary(result)  :58-67  # A compact human summary of what squeeze would do (for the pr
 ```
 
 ### src/squeeze/jsonpayload.js
@@ -1282,41 +987,50 @@ function squeezeJsonPayload(input, opts = {}) → { squeezed, kept, strippe  :41
 ### src/squeeze/stacktrace.js
 ```
 module.exports = { squeezeStackTrace, parseFrame, isVendor, inSrcDirs, enrichFrame }  :135-135
-function parseFrame(line)  :20-28
+function parseFrame(line)  :20-28  # Parse a frame line across JS/TS, Python, Java/Kotlin, Go, Ru
 function isVendor(file)  :30-30
 function inSrcDirs(file, srcDirs)  :32-38
-function enrichFrame(frame, symbolIndex)  :41-66
+function enrichFrame(frame, symbolIndex)  :41-66  # Look up the real signature for a frame in the SigMap symbol 
 function squeezeStackTrace(input, opts = {}) → { squeezed, kept, strippe  :76-133
 ```
 
 ### src/tracking/aggregate.js
 ```
 module.exports = { aggregate, bucketBy, parseSince, normalize }  :195-195
-function normalize(rec)  :25-44
+function normalize(rec)  :25-44  # Normalize one raw record into a canonical shape
 function normalizeOp(op)  :46-49
 function num(v)  :51-54
-function parseSince(since, nowMs) → Date|null  :63-75
-function bucketBy(records, granularity) → Array<{key,count,baseline  :83-100
+function parseSince(since, nowMs) → Date|null  :63-75  # Parse a --since value into a cutoff Date (or null for "all t
+function bucketBy(records, granularity) → Array<{key,count,baseline  :83-100  # Bucket records by calendar granularity
 function bucketKey(ts, granularity)  :102-117
-function aggregate(rawRecords, opts = {}) → object  :129-193
+function aggregate(rawRecords, opts = {}) → object  :129-193  # Full aggregation for the `gain` dashboard
+```
+
+### src/tracking/budget.js
+```
+module.exports = { sessionKey, budgetStatus, contextMtime, entryInSession }  :113-113
+function sessionKey(env)  :30-34  # Session key: SIGMAP_SESSION override, else UTC day bucket
+function contextMtime(cwd)  :37-43  # Newest mtime (ms) among generated context files, or 0 if non
+function entryInSession(entry, session)  :46-50  # Does a gain-log entry belong to this session
+function budgetStatus(cwd, opts = {}) → { * session: string, unit  :70-111  # Session spend status
 ```
 
 ### src/tracking/logger.js
 ```
-module.exports = { logRun, recordUsage, readLog, readGainLog, summarize, isTrackingEnabled, GAIN_FILE }  :197-197
-function logRun(entry, cwd)  :30-55
-function readLog(cwd) → object[]  :62-77
-function readGainLog(cwd) → object[]  :84-96
-function summarize(entries) → object  :103-135
-function isTrackingEnabled(config, argv) → boolean  :147-153
-function recordUsage(entry, cwd)  :169-195
+module.exports = { logRun, recordUsage, readLog, readGainLog, summarize, isTrackingEnabled, GAIN_FILE }  :199-199
+function logRun(entry, cwd)  :30-55  # Append one run entry to the usage log
+function readLog(cwd) → object[]  :62-77  # Read and parse all usage log entries
+function readGainLog(cwd) → object[]  :84-96  # Read and parse all `gain` dashboard records (oldest first)
+function summarize(entries) → object  :103-135  # Compute summary statistics from an array of log records
+function isTrackingEnabled(config, argv) → boolean  :147-153  # Whether `gain` savings capture is enabled
+function recordUsage(entry, cwd)  :169-197  # Append one operation to the usage log using the extended `ga
 ```
 
 ### src/tracking/pricing.js
 ```
-module.exports = { PRICES, DEFAULT_MODEL, resolvePrice, listModels }  :44-44
-function resolvePrice(model) → { model: string, perMtok:  :32-37
-function listModels() → string[]  :40-42
+module.exports = { PRICES, DEFAULT_MODEL, resolvePrice, listModels }  :46-46
+function resolvePrice(model) → { model: string, perMtok:  :34-39  # Resolve a price (USD per token) for a model name
+function listModels() → string[]  :42-44
 ```
 
 ### src/util/git.js
@@ -1329,57 +1043,67 @@ function tryGit(args, opts = {})  :26-29
 ### src/util/truncate.js
 ```
 module.exports = { capWithNotice, capMembersWithNotice }  :42-42
-function capWithNotice(items, limit, label) → string[]  :22-26
-function capMembersWithNotice(members, limit, label = 'methods') → Array<{text:string  :36-40
+function capWithNotice(items, limit, label) → string[]  :22-26  # Cap a string array, appending a `… +N more <label>` marker w
+function capMembersWithNotice(members, limit, label = 'methods') → Array<{text:string  :36-40  # Cap an array of member objects ({ text,
+```
+
+### src/verify/arity.js
+```
+module.exports = { parseParams, buildArityIndex, extractCallArgCounts, checkArity, cleanSig, EXACT_PARAM_EXTS }  :180-180
+function cleanSig(sig)  :35-37  # Strip the `  :start-end` anchor and `  # hint` tail from a s
+function parseParams(paramText) → { min: number, max: numbe  :47-84  # Parse a parameter-list string into an arity range
+function buildArityIndex(sigIndex) → Map<string, { min, max, v  :93-122  # Build a per-name arity index from a SigMap signature index
+function extractCallArgCounts(code) → { name: string, args: num  :132-166  # Extract call sites with argument counts from answer code
+function checkArity(name, argCount, arityIndex) → null | { min, max, variad  :172-178  # Check one call against the arity index
 ```
 
 ### src/verify/closest-match.js
 ```
 module.exports = { levenshtein, closestMatch, buildSymbolCandidates, suggestionConfidence, formatSuggestion }  :139-145
-function levenshtein(a, b, max = Infinity)  :20-47
-function suggestionConfidence(distance, targetLen)  :50-55
-function closestMatch(target, candidates, opts = {}) → { name, file, line, dista  :67-98
-function buildSymbolCandidates(sigIndex)  :104-126
-function formatSuggestion(match, asCall)  :129-137
+function levenshtein(a, b, max = Infinity)  :20-47  # Levenshtein edit distance with an early-exit ceiling
+function suggestionConfidence(distance, targetLen)  :50-55  # Bucket a normalized edit distance into a confidence label (p
+function closestMatch(target, candidates, opts = {}) → { name, file, line, dista  :67-98  # Find the nearest candidate name to `target`
+function buildSymbolCandidates(sigIndex)  :104-126  # Build `[{ name, file, line }]` symbol candidates from a SigM
+function formatSuggestion(match, asCall)  :129-137  # Format a suggestion object into a human one-liner for report
 ```
 
 ### src/verify/hallucination-guard.js
 ```
-module.exports = { verify, buildSymbolSet, loadDeps, loadScripts, isTestPath }  :345-345
-function isTestPath(p)  :29-29
-function buildSymbolSet(cwd)  :76-94
-function loadDeps(cwd)  :97-110
-function loadScripts(cwd)  :113-122
-function defaultFileExists(cwd, ref)  :125-133
-function defaultRelativeResolvable(cwd, mod, fileBasenames)  :136-153
-function verify(answerText, cwd, opts = {}) → { issues: object[], summa  :177-301
+module.exports = { verify, buildSymbolSet, loadDeps, loadScripts, isTestPath }  :378-378
+function isTestPath(p)  :30-30
+function buildSymbolSet(cwd)  :77-97  # Build the set of known symbol identifiers from the SigMap si
+function loadDeps(cwd)  :100-113  # Load declared dependency names from package
+function loadScripts(cwd)  :116-125  # Load the set of npm script names declared in package
+function defaultFileExists(cwd, ref)  :128-136  # Default file-existence check: resolve a referenced path agai
+function defaultRelativeResolvable(cwd, mod, fileBasenames)  :139-156  # Default relative-import resolver: fs candidates + basename m
+function verify(answerText, cwd, opts = {}) → { issues: object[], summa  :180-282  # Verify an AI answer against the repository
 ```
 
 ### src/verify/lib-index.js
 ```
 module.exports = { buildLibraryIndex, extractDtsExports, directDeps, resolveEntry, formatVersionPins, collectVersionPins, extractPyExports, pythonDirectDeps, findSitePackages, resolvePyEntry }  :329-333
-function extractDtsExports(src) → string[]  :40-50
-function directDeps(cwd)  :68-79
-function resolveEntry(cwd, dep) → { version: string|null, d  :85-105
-function extractPyExports(src) → string[]  :118-146
-function pythonDirectDeps(cwd)  :149-172
-function findSitePackages(cwd)  :175-190
-function normalizePy(name)  :193-195
-function findPyVersion(sitePkgsDir, dep)  :198-207
-function resolvePyEntry(sitePkgsDirs, dep) → { version: string|null, s  :213-229
-function buildLibraryIndex(cwd, opts = {}) → { symbols: Set<string>, l  :240-292
-function formatVersionPins(libraries)  :295-299
-function collectVersionPins(cwd, opts = {}) → { pins: string[], total:   :311-327
+function extractDtsExports(src) → string[]  :40-50  # Extract exported symbol names from a `
+function directDeps(cwd)  :68-79  # Read direct dependency names declared in the project's packa
+function resolveEntry(cwd, dep) → { version: string|null, d  :85-105  # Resolve an installed dependency's version + entry `
+function extractPyExports(src) → string[]  :118-146  # Extract exported symbol names from a Python module's `__init
+function pythonDirectDeps(cwd)  :149-172  # Read direct Python dependency names from requirements
+function findSitePackages(cwd)  :175-190  # Locate the project's venv `site-packages` directories (no Py
+function normalizePy(name)  :193-195  # PEP 503 name normalization (case-insensitive, `-`/`_`/`
+function findPyVersion(sitePkgsDir, dep)  :198-207  # Find an installed distribution's version from its `*
+function resolvePyEntry(sitePkgsDirs, dep) → { version: string|null, s  :213-229  # Resolve a Python dependency to its installed module entry fi
+function buildLibraryIndex(cwd, opts = {}) → { symbols: Set<string>, l  :240-292  # Build the installed-library signature index for `cwd`
+function formatVersionPins(libraries)  :295-299  # D8: render `name@version` pins for the typed/installed libra
+function collectVersionPins(cwd, opts = {}) → { pins: string[], total:   :311-327  # D8: collect `name@version` pins for direct dependencies — ve
 ```
 
 ### src/verify/parsers.js
 ```
 module.exports = { extractCodeBlocks, extractFilePaths, extractImports, extractSymbols, extractNpmScripts }  :211-217
-function extractCodeBlocks(text) → { lang: string, content:   :43-67
-function extractFilePaths(text) → { path: string, line: num  :76-97
-function extractImports(text) → { module: string, kind: '  :104-159
-function extractNpmScripts(text) → { name: string, line: num  :168-184
-function extractSymbols(text) → { name: string, line: num  :192-209
+function extractCodeBlocks(text) → { lang: string, content:   :43-155  # Extract fenced code blocks
+function extractFilePaths(text) → { path: string, line: num  :76-95  # Extract file-path references (deduped, first-seen line kept)
+function extractImports(text) → { module: string, kind: '  :104-137  # Extract import / require statements
+function extractNpmScripts(text) → { name: string, line: num  :168-184  # Extract npm/pnpm/yarn script invocations (`npm run <name>`)
+function extractSymbols(text) → { name: string, line: num  :192-217  # Extract function/class symbol references that look like call
 ```
 
 ### src/wiki/generate.js
@@ -1387,20 +1111,11 @@ function extractSymbols(text) → { name: string, line: num  :192-209
 module.exports = { buildWiki, renderWikiMarkdown }  :250-250
 function _rel(cwd, f)  :22-24
 function _pct(fraction)  :26-28
-function _identity(cwd)  :31-37
-function _modules(index)  :40-67
-function _flow(cwd)  :70-97
-function _conventions(cwd, index)  :100-117
+function _identity(cwd)  :31-37  # Project name + version from package
+function _modules(index)  :40-67  # Module rollup from the signature index (keys are cwd-relativ
+function _flow(cwd)  :70-97  # Hubs, entry points, and cycle count from the dependency grap
+function _conventions(cwd, index)  :100-117  # Conventions summary; index keys are resolved back to absolut
 function _health(cwd)  :119-127
-function buildWiki(cwd, opts = {}) → { data: object, markdown:  :137-162
-function renderWikiMarkdown(data, sigmapVersion) → string  :171-248
-```
-
-### src/workspace/detector.js
-```
-module.exports = { detectWorkspaces, inferPackage, scopeToPackage }  :4-4
-function detectWorkspaces(cwd)  :6-36
-function inferPackage(query, workspaceDirs, cwd)  :39-61
-function _getMatchLength(name, token)  :63-68
-function scopeToPackage(filePath, packageDir)  :71-85
+function buildWiki(cwd, opts = {}) → { data: object, markdown:  :137-162  # Build the wiki
+function renderWikiMarkdown(data, sigmapVersion) → string  :171-248  # Render the narrative markdown
 ```

--- a/benchmarks/retrieval-baseline.json
+++ b/benchmarks/retrieval-baseline.json
@@ -1,0 +1,21 @@
+{
+  "hard": {
+    "hitAt5": 0.767,
+    "mrr": 0.639,
+    "precisionAt5": 0.153,
+    "tasks": 90
+  },
+  "mined": {
+    "hitAt5": 0.609,
+    "mrr": 0.447,
+    "precisionAt5": 0.13,
+    "tasks": 23
+  },
+  "easy": {
+    "hitAt5": 0.9,
+    "mrr": 0.825,
+    "precisionAt5": 0.22,
+    "tasks": 20
+  },
+  "recordedBy": "run-retrieval-gate.mjs"
+}

--- a/benchmarks/tasks/retrieval-hard.jsonl
+++ b/benchmarks/tasks/retrieval-hard.jsonl
@@ -1,0 +1,90 @@
+{"id": "h001", "split": "hard", "query": "stop credentials from leaking into generated output", "expected_files": ["src/security/scanner.js", "src/security/redact.js"], "repo": "."}
+{"id": "h002", "split": "hard", "query": "which files does the rest of the repo depend on most", "expected_files": ["src/graph/centrality.js"], "repo": "."}
+{"id": "h003", "split": "hard", "query": "confirm a suggested call passes the right number of arguments", "expected_files": ["src/verify/arity.js"], "repo": "."}
+{"id": "h004", "split": "hard", "query": "shrink a pasted exception dump before ranking it", "expected_files": ["src/squeeze/stacktrace.js"], "repo": "."}
+{"id": "h005", "split": "hard", "query": "flag files that disagree with the dominant naming style", "expected_files": ["src/conventions/conflicts.js"], "repo": "."}
+{"id": "h006", "split": "hard", "query": "how much money does one query cost for a given model", "expected_files": ["src/tracking/pricing.js"], "repo": "."}
+{"id": "h007", "split": "hard", "query": "what else breaks if I change this one function", "expected_files": ["src/graph/blast-radius.js"], "repo": "."}
+{"id": "h008", "split": "hard", "query": "remember something for later on the current branch", "expected_files": ["src/session/notes.js"], "repo": "."}
+{"id": "h009", "split": "hard", "query": "launch the watcher in the background and stop it later", "expected_files": ["src/daemon/daemon.js"], "repo": "."}
+{"id": "h010", "split": "hard", "query": "make signature lines shorter to save tokens", "expected_files": ["src/format/terse.js"], "repo": "."}
+{"id": "h011", "split": "hard", "query": "compare model answers with and without grounding", "expected_files": ["src/eval/llm-ablation.js"], "repo": "."}
+{"id": "h012", "split": "hard", "query": "register the server with Cursor and Zed", "expected_files": ["src/mcp/install.js"], "repo": "."}
+{"id": "h013", "split": "hard", "query": "create a new file that follows existing repo style", "expected_files": ["src/scaffold/propose.js"], "repo": "."}
+{"id": "h014", "split": "hard", "query": "suggest the nearest real symbol when a name is wrong", "expected_files": ["src/verify/closest-match.js"], "repo": "."}
+{"id": "h015", "split": "hard", "query": "trim continuous integration output down to the failing lines", "expected_files": ["src/squeeze/cilog.js"], "repo": "."}
+{"id": "h016", "split": "hard", "query": "how many tokens have I spent in this working session", "expected_files": ["src/tracking/budget.js"], "repo": "."}
+{"id": "h017", "split": "hard", "query": "turn a natural language question into weighted scoring signals", "expected_files": ["src/retrieval/ranker.js", "src/retrieval/bm25.js"], "repo": "."}
+{"id": "h018", "split": "hard", "query": "walk a directory tree and decide where the code actually lives", "expected_files": ["src/discovery/source-root-resolver.js", "src/discovery/source-root-scorer.js"], "repo": "."}
+{"id": "h019", "split": "hard", "query": "adjust how strongly a file is favoured based on past runs", "expected_files": ["src/learning/weights.js"], "repo": "."}
+{"id": "h020", "split": "hard", "query": "figure out which package of a monorepo a question belongs to", "expected_files": ["src/workspace/detector.js"], "repo": "."}
+{"id": "h021", "split": "hard", "query": "carry the previous question's files into a follow-up", "expected_files": ["src/session/memory.js"], "repo": "."}
+{"id": "h022", "split": "hard", "query": "recognise that a project uses Django or Rails", "expected_files": ["src/discovery/framework-detector.js"], "repo": "."}
+{"id": "h023", "split": "hard", "query": "skip re-extracting files that have not been modified", "expected_files": ["src/cache/sig-cache.js"], "repo": "."}
+{"id": "h024", "split": "hard", "query": "how many files were left out when the budget was applied", "expected_files": ["src/analysis/coverage-score.js"], "repo": "."}
+{"id": "h025", "split": "hard", "query": "pick which model tier a task needs", "expected_files": ["src/routing/classifier.js"], "repo": "."}
+{"id": "h026", "split": "hard", "query": "collect leftover reminders developers left in comments", "expected_files": ["src/extractors/todos.js"], "repo": "."}
+{"id": "h027", "split": "hard", "query": "map which types inherit from which", "expected_files": ["src/map/class-hierarchy.js"], "repo": "."}
+{"id": "h028", "split": "hard", "query": "find circular references between modules", "expected_files": ["src/map/import-graph.js"], "repo": "."}
+{"id": "h029", "split": "hard", "query": "split camelCase identifiers into separate words", "expected_files": ["src/retrieval/tokenizer.js"], "repo": "."}
+{"id": "h030", "split": "hard", "query": "wrap context so Anthropic can reuse it between calls", "expected_files": ["src/format/cache.js"], "repo": "."}
+{"id": "h031", "split": "hard", "query": "append to an assistant file without clobbering hand-written notes", "expected_files": ["packages/adapters/claude.js"], "repo": "."}
+{"id": "h032", "split": "hard", "query": "emit a rules file the editor reads on every workspace open", "expected_files": ["packages/adapters/cursor.js"], "repo": "."}
+{"id": "h033", "split": "hard", "query": "the public programmatic entry points other code imports", "expected_files": ["packages/core/index.js"], "repo": "."}
+{"id": "h034", "split": "hard", "query": "explain why a particular file was left out", "expected_files": ["src/analysis/diagnostics.js"], "repo": "."}
+{"id": "h035", "split": "hard", "query": "keep signatures in step with edits since the last run", "expected_files": ["src/cache/freshen.js"], "repo": "."}
+{"id": "h036", "split": "hard", "query": "recommend better settings for this repository automatically", "expected_files": ["src/config/tune.js"], "repo": "."}
+{"id": "h037", "split": "hard", "query": "fail the build when house style consistency drops", "expected_files": ["src/conventions/ci.js"], "repo": "."}
+{"id": "h038", "split": "hard", "query": "work out the dominant coding style of a repo", "expected_files": ["src/conventions/extract.js"], "repo": "."}
+{"id": "h039", "split": "hard", "query": "list every file that should be renamed to match house style", "expected_files": ["src/conventions/fix.js"], "repo": "."}
+{"id": "h040", "split": "hard", "query": "run the guard stages in sequence for grounded creation", "expected_files": ["src/create/orchestrate.js"], "repo": "."}
+{"id": "h041", "split": "hard", "query": "one-shot setup check with an actionable remedy per problem", "expected_files": ["src/doctor/diagnose.js"], "repo": "."}
+{"id": "h042", "split": "hard", "query": "per-file statistics about what was pulled out of each source", "expected_files": ["src/eval/analyzer.js"], "repo": "."}
+{"id": "h043", "split": "hard", "query": "make sure benchmark queries do not give away their answer", "expected_files": ["src/eval/corpus.js"], "repo": "."}
+{"id": "h044", "split": "hard", "query": "compute hit rate and reciprocal rank metrics", "expected_files": ["src/eval/scorer.js"], "repo": "."}
+{"id": "h045", "split": "hard", "query": "a machine-readable bundle of proof for one question", "expected_files": ["src/evidence/pack.js"], "repo": "."}
+{"id": "h046", "split": "hard", "query": "read selectors and rules out of stylesheets", "expected_files": ["src/extractors/css.js"], "repo": "."}
+{"id": "h047", "split": "hard", "query": "choose the right parser for a given file type", "expected_files": ["src/extractors/dispatch.js"], "repo": "."}
+{"id": "h048", "split": "hard", "query": "render a savings dashboard with coloured bars for the console", "expected_files": ["src/format/gain-terminal.js"], "repo": "."}
+{"id": "h049", "split": "hard", "query": "the identical how-to block every adapter emits", "expected_files": ["src/format/usage-guidance.js"], "repo": "."}
+{"id": "h050", "split": "hard", "query": "turn guard results into a standalone HTML page", "expected_files": ["src/format/verify-report.js"], "repo": "."}
+{"id": "h051", "split": "hard", "query": "resolve import statements into a dependency map", "expected_files": ["src/graph/builder.js"], "repo": "."}
+{"id": "h052", "split": "hard", "query": "everything that transitively imports a changed file", "expected_files": ["src/graph/impact.js"], "repo": "."}
+{"id": "h053", "split": "hard", "query": "give the project a 0-100 grade with a breakdown of deductions", "expected_files": ["src/health/scorer.js"], "repo": "."}
+{"id": "h054", "split": "hard", "query": "surface the scripts and workflows that compile and check a project", "expected_files": ["src/map/build-ci.js"], "repo": "."}
+{"id": "h055", "split": "hard", "query": "which environment variables does the code actually read", "expected_files": ["src/map/env-schema.js"], "repo": "."}
+{"id": "h056", "split": "hard", "query": "find database schema change files across frameworks", "expected_files": ["src/map/migrations.js"], "repo": "."}
+{"id": "h057", "split": "hard", "query": "speak JSON-RPC over standard input and output", "expected_files": ["src/mcp/server.js"], "repo": "."}
+{"id": "h058", "split": "hard", "query": "the catalogue of callable operations exposed to an agent", "expected_files": ["src/mcp/tools.js"], "repo": "."}
+{"id": "h059", "split": "hard", "query": "show a one-time star message after enough successful runs", "expected_files": ["src/nudge.js"], "repo": "."}
+{"id": "h060", "split": "hard", "query": "validate a written proposal before any of it is executed", "expected_files": ["src/plan/verify-plan.js"], "repo": "."}
+{"id": "h061", "split": "hard", "query": "fold route surfaces into the ranking candidates", "expected_files": ["src/retrieval/enrich-from-maps.js"], "repo": "."}
+{"id": "h062", "split": "hard", "query": "keep the full symbol list apart from what goes in the prompt", "expected_files": ["src/retrieval/sig-index-store.js"], "repo": "."}
+{"id": "h063", "split": "hard", "query": "a branded summary of a changeset for reviewers", "expected_files": ["src/review/pr-evidence.js"], "repo": "."}
+{"id": "h064", "split": "hard", "query": "audit a changeset for creep beyond what was asked", "expected_files": ["src/review/review-pr.js"], "repo": "."}
+{"id": "h065", "split": "hard", "query": "which complexity tier maps to which example model", "expected_files": ["src/routing/hints.js"], "repo": "."}
+{"id": "h066", "split": "hard", "query": "write an accepted proposal record to disk", "expected_files": ["src/scaffold/persist.js"], "repo": "."}
+{"id": "h067", "split": "hard", "query": "the regexes that spot API keys and credentials", "expected_files": ["src/security/patterns.js"], "repo": "."}
+{"id": "h068", "split": "hard", "query": "show what cross-session state is kept and let me clear it", "expected_files": ["src/session/memory-inspect.js"], "repo": "."}
+{"id": "h069", "split": "hard", "query": "install agent playbooks for several different clients", "expected_files": ["src/skills/skills.js"], "repo": "."}
+{"id": "h070", "split": "hard", "query": "decide what kind of text somebody just pasted in", "expected_files": ["src/squeeze/classify.js"], "repo": "."}
+{"id": "h071", "split": "hard", "query": "decide whether minimising pasted input is worth asking about", "expected_files": ["src/squeeze/index.js"], "repo": "."}
+{"id": "h072", "split": "hard", "query": "collapse repeated array elements while keeping the shape", "expected_files": ["src/squeeze/jsonpayload.js"], "repo": "."}
+{"id": "h073", "split": "hard", "query": "turn raw usage records into totals by day and week", "expected_files": ["src/tracking/aggregate.js"], "repo": "."}
+{"id": "h074", "split": "hard", "query": "append one record per operation to an append-only file", "expected_files": ["src/tracking/logger.js"], "repo": "."}
+{"id": "h075", "split": "hard", "query": "invoke version control directly without spawning a shell", "expected_files": ["src/util/git.js"], "repo": "."}
+{"id": "h076", "split": "hard", "query": "show a visible marker when signatures were capped", "expected_files": ["src/util/truncate.js"], "repo": "."}
+{"id": "h077", "split": "hard", "query": "flag statements in an answer contradicted by the actual code", "expected_files": ["src/verify/hallucination-guard.js"], "repo": "."}
+{"id": "h078", "split": "hard", "query": "catalogue exported symbols of installed third-party packages", "expected_files": ["src/verify/lib-index.js"], "repo": "."}
+{"id": "h079", "split": "hard", "query": "pull referenced paths and imports out of an answer", "expected_files": ["src/verify/parsers.js"], "repo": "."}
+{"id": "h080", "split": "hard", "query": "produce a readable architecture narrative document", "expected_files": ["src/wiki/generate.js"], "repo": "."}
+{"id": "h081", "split": "hard", "query": "build edges showing which routine invokes which other routine", "expected_files": ["src/graph/call-graph.js"], "repo": "."}
+{"id": "h082", "split": "hard", "query": "merge user settings with defaults and auto-detected roots", "expected_files": ["src/config/loader.js"], "repo": "."}
+{"id": "h083", "split": "hard", "query": "honour a file listing paths that should be skipped", "expected_files": ["src/discovery/sigmapignore.js"], "repo": "."}
+{"id": "h084", "split": "hard", "query": "determine which syntaxes appear across a checkout", "expected_files": ["src/discovery/language-detector.js"], "repo": "."}
+{"id": "h085", "split": "hard", "query": "surface each ecosystem's package metadata and dependency counts", "expected_files": ["src/map/config-manifest.js"], "repo": "."}
+{"id": "h086", "split": "hard", "query": "the implementations behind each agent-callable operation", "expected_files": ["src/mcp/handlers.js"], "repo": "."}
+{"id": "h087", "split": "hard", "query": "the built-in settings applied before any overrides", "expected_files": ["src/config/defaults.js"], "repo": "."}
+{"id": "h088", "split": "hard", "query": "write instructions the GitHub assistant picks up automatically", "expected_files": ["packages/adapters/copilot.js"], "repo": "."}
+{"id": "h089", "split": "hard", "query": "read package metadata for the R ecosystem", "expected_files": ["src/discovery/r-manifest.js"], "repo": "."}
+{"id": "h090", "split": "hard", "query": "the guard-rail block written in during first-time setup", "expected_files": ["src/init/creation-workflow.js"], "repo": "."}

--- a/benchmarks/tasks/retrieval-mined.jsonl
+++ b/benchmarks/tasks/retrieval-mined.jsonl
@@ -1,0 +1,23 @@
+{"id":"m001","split":"hard","source":"git","sha":"05bcfc9d","query":"shared balanced scanner — JS/TS nested-paren fix","expected_files":["gen-context.js"],"repo":"."}
+{"id":"m002","split":"hard","source":"git","sha":"4d4f93dd","query":"sigmap budget session spend ledger + get_budget tool","expected_files":["gen-context.js"],"repo":"."}
+{"id":"m003","split":"hard","source":"git","sha":"2abd4338","query":"line anchors for Kotlin, Swift, PHP, Scala, and Dart","expected_files":["gen-context.js"],"repo":"."}
+{"id":"m004","split":"hard","source":"git","sha":"08032fc7","query":"line anchors for Java, Go, Rust, and C#","expected_files":["gen-context.js"],"repo":"."}
+{"id":"m005","split":"hard","source":"git","sha":"da6cd953","query":"method-level blast-radius scoring wired into review-pr, PR Evidence, and MCP","expected_files":["gen-context.js"],"repo":"."}
+{"id":"m006","split":"hard","source":"git","sha":"9e6aa1c4","query":"merge hot-cold cache and context-cold into MCP index","expected_files":["src/mcp/handlers.js","src/retrieval/ranker.js"],"repo":"."}
+{"id":"m007","split":"hard","source":"git","sha":"daf9fcd0","query":"implement case-insensitive path normalization for Windows compatibility","expected_files":["src/graph/builder.js"],"repo":"."}
+{"id":"m008","split":"hard","source":"git","sha":"b6229395","query":"DESCRIPTION + NAMESPACE awareness for R packages","expected_files":["src/discovery/r-manifest.js"],"repo":"."}
+{"id":"m009","split":"hard","source":"git","sha":"40740eb0","query":"R6, S7, and roxygen2 hints in","expected_files":["src/extractors/r.js"],"repo":"."}
+{"id":"m010","split":"hard","source":"git","sha":"ee25d9ee","query":"add Python absolute imports to for get_impact","expected_files":["src/graph/builder.js"],"repo":"."}
+{"id":"m011","split":"hard","source":"git","sha":"9ee9e0ce","query":"normalize Windows path separators in nested path deduplication","expected_files":["src/discovery/source-root-resolver.js"],"repo":"."}
+{"id":"m012","split":"hard","source":"git","sha":"3edb85de","query":"query-aware retrieval + query_context MCP tool","expected_files":["src/retrieval/ranker.js"],"repo":"."}
+{"id":"m013","split":"hard","source":"git","sha":"56b656b6","query":"benchmark & evaluation system","expected_files":["src/eval/runner.js"],"repo":"."}
+{"id":"m014","split":"hard","source":"git","sha":"325d8da3","query":"add explain_file and list_modules tools (v1.4)","expected_files":["src/mcp/handlers.js"],"repo":"."}
+{"id":"m015","split":"hard","source":"git","sha":"a88b9096","query":"correct fast tier GPT model — gpt-5-mini (0x) → gpt-5-1-codex-mini (0.33x)","expected_files":["src/routing/hints.js"],"repo":"."}
+{"id":"m016","split":"hard","source":"git","sha":"b41b8e12","query":"update model names to current (April 2026)","expected_files":["src/routing/hints.js"],"repo":"."}
+{"id":"m017","split":"hard","source":"git","sha":"47bf0237","query":"add --health composite score output","expected_files":["src/health/scorer.js"],"repo":"."}
+{"id":"m018","split":"hard","source":"git","sha":"65824e1b","query":"add --report --json flag for CI token reporting","expected_files":["src/tracking/logger.js"],"repo":"."}
+{"id":"m019","split":"hard","source":"git","sha":"da5d7841","query":"add get_routing tool — 5th MCP tool","expected_files":["src/mcp/handlers.js"],"repo":"."}
+{"id":"m020","split":"hard","source":"git","sha":"d9ba611d","query":"add create_checkpoint tool — session state snapshot","expected_files":["src/mcp/handlers.js"],"repo":"."}
+{"id":"m021","split":"hard","source":"git","sha":"69bd314b","query":"scaffold — zero deps entry point","expected_files":["gen-project-map.js"],"repo":"."}
+{"id":"m022","split":"hard","source":"git","sha":"7f587ed2","query":"add external config file support with deep merge and unknown-key warnings","expected_files":["src/config/loader.js"],"repo":"."}
+{"id":"m023","split":"hard","source":"git","sha":"6c7f9af2","query":"add TypeScript and JavaScript extractors","expected_files":["src/extractors/javascript.js","src/extractors/typescript.js"],"repo":"."}

--- a/gen-context.js
+++ b/gen-context.js
@@ -4623,47 +4623,12 @@ __factories["./src/eval/runner"] = function(module, exports) {
    * @returns {Map<string, string[]>}
    */
   function buildSigIndex(cwd) {
-    const contextPath = path.join(cwd, '.github', 'copilot-instructions.md');
-    const index = new Map();
-
-    if (!fs.existsSync(contextPath)) return index;
-
-    const content = fs.readFileSync(contextPath, 'utf8');
-    const lines = content.split('\n');
-
-    let currentFile = null;
-    let inBlock = false;
-    let sigs = [];
-
-    for (const line of lines) {
-      // Section header: ### path/to/file.js
-      const headerMatch = line.match(/^###\s+(\S+\.\w+)\s*$/);
-      if (headerMatch) {
-        if (currentFile !== null) {
-          index.set(currentFile, sigs);
-        }
-        currentFile = headerMatch[1];
-        sigs = [];
-        inBlock = false;
-        continue;
-      }
-
-      if (line.startsWith('```')) {
-        inBlock = !inBlock;
-        continue;
-      }
-
-      if (inBlock && currentFile && line.trim()) {
-        sigs.push(line.trim());
-      }
-    }
-
-    // Flush last file
-    if (currentFile !== null) {
-      index.set(currentFile, sigs);
-    }
-
-    return index;
+    // Delegate to the production index builder. This used to parse
+    // .github/copilot-instructions.md directly — a second parallel implementation
+    // that saw only the token-BUDGETED view, ignored the other adapters, the
+    // hot-cold/per-module strategy splits, and the complete retrieval index. The
+    // corpus therefore scored a smaller index than `sigmap ask` actually uses.
+    return __require('./src/retrieval/ranker').buildSigIndex(cwd);
   }
 
   // ---------------------------------------------------------------------------
@@ -4681,12 +4646,13 @@ __factories["./src/eval/runner"] = function(module, exports) {
    * @param {number} topK
    * @returns {{ file: string, score: number, sigs: string[] }[]}
    */
-  function rank(query, index, topK = 10) {
-    const candidates = [];
-    for (const [file, sigs] of index.entries()) {
-      candidates.push({ file, sigs });
-    }
-    return bm25rank(query, candidates).slice(0, topK);
+  function rank(query, index, topK = 10, opts = {}) {
+    // Measure the ranker users actually hit. This used to call bm25rank directly,
+    // which meant the corpus scored a parallel implementation with no penalties,
+    // graph boost, recency or learned weights — so no ranking regression in
+    // src/retrieval/ranker.js could ever show up in the benchmark numbers.
+    const { rank: prodRank } = __require('./src/retrieval/ranker');
+    return prodRank(query, index, Object.assign({ topK }, opts)).slice(0, topK);
   }
 
   // ---------------------------------------------------------------------------
@@ -4773,11 +4739,14 @@ __factories["./src/eval/runner"] = function(module, exports) {
 
     // Build index once (re-used across all tasks in the same repo)
     const index = buildSigIndex(cwd);
+    // Import graph built once too — the hop-1/hop-2 boost is part of what ships.
+    let graph = null;
+    try { graph = __require('./src/graph/builder').buildFromCwd(cwd); } catch (_) {}
 
     const taskResults = [];
     for (const task of tasks) {
-      const ranked = rank(task.query, index, topK).map((r) => r.file);
-      const topResult = rank(task.query, index, topK);
+      const topResult = rank(task.query, index, topK, { cwd, graph, learned: opts.learned });
+      const ranked = topResult.map((r) => r.file);
       const tokens = topResult.reduce((sum, r) => sum + estimateTokens(r.sigs), 0);
 
       const { hitAtK, reciprocalRank, precisionAtK } = __require('./src/eval/scorer');
@@ -11345,10 +11314,11 @@ __factories["./src/graph/builder"] = function(module, exports) {
   const fs   = require('fs');
   const path = require('path');
 
-  // Normalize paths for cross-platform consistency (Windows uses backslashes, Unix uses forward slashes)
-  // Use lowercase to enable case-insensitive lookups on case-sensitive Windows filesystems
+  // Cross-platform node key. Delegates to the ONE shared definition so this graph
+  // and the call-graph cannot drift apart again (see src/graph/path-key.js).
+  const { graphKey } = __require('./src/graph/path-key');
   function normalizePath(p) {
-    return path.normalize(p).toLowerCase();
+    return graphKey(p);
   }
 
   // ---------------------------------------------------------------------------
@@ -11877,7 +11847,8 @@ __factories["./src/graph/call-graph"] = function(module, exports) {
     'synchronized',
   ]);
 
-  function normalizePath(p) { return path.normalize(p).toLowerCase(); }
+  const { graphKey } = __require('./src/graph/path-key');
+  function normalizePath(p) { return graphKey(p); }
   function toRel(cwd, f) { return path.relative(cwd, f).replace(/\\/g, '/'); }
   function symId(cwd, absFile, name) { return `${toRel(cwd, absFile)}#${name}`; }
 
@@ -12309,8 +12280,11 @@ __factories["./src/graph/call-graph"] = function(module, exports) {
       for (const calleeId of calleeIds) {
         const calleeDef = graph.defs.get(calleeId);
         if (!calleeDef || calleeDef.file === callerDef.file) continue;
-        const a = path.resolve(cwd, callerDef.file);
-        const b = path.resolve(cwd, calleeDef.file);
+        // Keyed through graphKey so the file-level call graph shares ONE key space
+        // with the import graph. Previously this kept case while builder.js
+        // lowercased, so a lookup correct for one silently missed on the other.
+        const a = graphKey(path.resolve(cwd, callerDef.file));
+        const b = graphKey(path.resolve(cwd, calleeDef.file));
         add(a, b);
         add(b, a);
       }
@@ -12713,6 +12687,36 @@ __factories["./src/graph/impact"] = function(module, exports) {
   }
 
   module.exports = { getImpact, analyzeImpact, formatImpact, formatImpactJSON };
+  
+};
+
+// ── ./src/graph/path-key ──
+__factories["./src/graph/path-key"] = function(module, exports) {
+  
+  /**
+   * The single definition of a graph node key.
+   *
+   * src/graph/builder.js and src/graph/call-graph.js each used to normalise paths
+   * their own way — builder lowercased, call-graph did not — so a lookup written
+   * for one silently missed on the other. That divergence disabled the import
+   * boost on every repo whose path contains an uppercase letter, and later caused
+   * a "fix" for one graph to break the other. Both now key through this function,
+   * so there is one convention rather than two conventions and a convention.
+   *
+   * Lowercasing keeps lookups stable across case-insensitive filesystems (macOS,
+   * Windows), where the same file legitimately arrives spelled two ways.
+   *
+   * Zero-dependency, pure, bundle-safe.
+   */
+
+  const path = require('path');
+
+  /** Canonical key for a filesystem path used as a graph node. */
+  function graphKey(p) {
+    return path.normalize(String(p)).toLowerCase();
+  }
+
+  module.exports = { graphKey };
   
 };
 
@@ -16357,6 +16361,33 @@ __factories["./src/retrieval/bm25"] = function(module, exports) {
   // the literal query token always outranks a synonym-only match.
   const EXPANSION_WEIGHT = 0.15;
 
+  // Module-doc prose is indexed as a `# module: ...` pseudo-signature (index-only,
+  // see src/retrieval/module-doc.js). Per token it is a weaker relevance signal
+  // than a real signature — descriptive rather than definitional — so it is scored
+  // as its own BM25F field rather than pooled with the code terms.
+  const MODULE_DOC_RE = /^#\s*(module|docs):/;
+
+  // Line anchors are metadata, not content, and this ranker is documented as
+  // anchor-invariant. The previous strip was end-anchored, so it only fired when
+  // the anchor was the last thing on the line — but extractors append a doc hint
+  // AFTER it ("... :27-59  # Compute a normalized centrality score"). 27% of
+  // signatures therefore leaked their line numbers into the term space as tokens
+  // like "27" and "59": 840 junk terms, inflating document length for exactly the
+  // well-documented files, which BM25 then penalised via length normalisation.
+  const ANCHOR_RE = /\s*:\d+(?:-\d+)?(?=\s|$)/g;
+
+  function stripAnchor(line) {
+    return String(line).replace(ANCHOR_RE, '');
+  }
+  // Tuned on the 30-task leak-free corpus. The 0.5-0.8 band is flat
+  // (hit@5 63.3-66.7%, easy MRR steady at 0.825); adjacent values swing by up to
+  // 6.7pp, which at 30 tasks is literally two tasks — noise, not signal. 0.6 is
+  // chosen from the middle of that band rather than at its peak, because a
+  // per-token weight below 1 is the principled position (prose is descriptive,
+  // a signature is definitional) and picking the argmax of a 30-task sweep is
+  // how you overfit a benchmark.
+  const DOC_WEIGHT = 0.6;
+
   // Build a stemmed lookup: stem(member) → Set of the group's other stemmed members.
   const EXPANSIONS = (() => {
     const map = new Map();
@@ -16400,22 +16431,45 @@ __factories["./src/retrieval/bm25"] = function(module, exports) {
    * @param {{ file: string, sigs: string[] }[]} candidates
    * @returns {Array<object & { score: number }>}
    */
-  function bm25rank(query, candidates) {
+  function bm25rank(query, candidates, opts) {
     if (!Array.isArray(candidates) || candidates.length === 0) return [];
 
     const k1 = 1.5;
     const b = 0.75;
+
+    const docWeight = (opts && typeof opts.docWeight === 'number') ? opts.docWeight : DOC_WEIGHT;
 
     const docs = candidates.map((c) => {
       const pathToks = tokenize(c.file || '');
       // Ranking is anchor-invariant: `:start-end` line anchors are metadata,
       // not content — strip them before tokenizing so adding anchors to an
       // extractor never shifts BM25 length normalization or token counts.
-      const toks = tokenize((c.sigs || []).map((s) => String(s).replace(/\s*:\d+(?:-\d+)?\s*$/, '')).join(' '));
-      for (let i = 0; i < PATH_BOOST; i++) toks.push(...pathToks);
+      // BM25F-style fields. Module-doc prose and code signatures are different
+      // kinds of evidence and must not share one term-frequency pool: prose is
+      // ~30% of all indexed tokens, and a short file with a long header (few
+      // signatures, lots of description) otherwise wins unrelated queries purely
+      // through length normalisation.
+      const docLines = [];
+      const codeLines = [];
+      for (const line of (c.sigs || [])) (MODULE_DOC_RE.test(line) ? docLines : codeLines).push(line);
+      // TRIED AND REJECTED: splitting the declared symbol NAME into its own
+      // weighted BM25F field, on the IR prior that a name is a "title" and params
+      // are "body". Swept 1.0-4.0. hit@5 on the mined corpus rose 60.9% -> 65.2%,
+      // which is a single task crossing the rank-5 line — over 113 combined tasks
+      // hit@1 fell 52.2% -> 51.3%, hit@3 fell 66.4% -> 65.5%, hit@10 was identical
+      // and MRR dropped. It moves correct answers DOWN and happens to nudge one
+      // past a cutoff. A hit@5-only view would have shipped this.
+      const codeToks = tokenize(codeLines.map((x) => stripAnchor(x)).join(' '));
+      const docToks = tokenize(docLines.join(' '));
       const tf = new Map();
-      for (const t of toks) tf.set(t, (tf.get(t) || 0) + 1);
-      return { cand: c, tf, len: toks.length };
+      const addField = (toks, weight) => { for (const t of toks) tf.set(t, (tf.get(t) || 0) + weight); };
+      addField(codeToks, 1);
+      addField(pathToks, PATH_BOOST);
+      addField(docToks, docWeight);
+      // Length accumulates with the SAME weights, or a field's influence leaks
+      // back in through the normalisation term.
+      const len = codeToks.length + (PATH_BOOST * pathToks.length) + (docWeight * docToks.length);
+      return { cand: c, tf, len };
     });
 
     const N = docs.length || 1;
@@ -16444,7 +16498,7 @@ __factories["./src/retrieval/bm25"] = function(module, exports) {
       .sort((a, c) => c.score - a.score || String(a.file).localeCompare(String(c.file)));
   }
 
-  module.exports = { tokenize, stem, bm25rank, PATH_BOOST, STOP, expandQuery, EXPANSIONS, EXPANSION_WEIGHT };
+  module.exports = { tokenize, stem, bm25rank, PATH_BOOST, STOP, expandQuery, EXPANSIONS, EXPANSION_WEIGHT, DOC_WEIGHT, MODULE_DOC_RE, stripAnchor };
   
 };
 
@@ -16507,6 +16561,130 @@ __factories["./src/retrieval/enrich-from-maps"] = function(module, exports) {
   
 };
 
+// ── ./src/retrieval/module-doc ──
+__factories["./src/retrieval/module-doc"] = function(module, exports) {
+  
+  /**
+   * Module-level documentation extractor (retrieval only).
+   *
+   * Signatures describe a file's SHAPE — names, params, return types. A module's
+   * leading comment describes its PURPOSE, in prose, using the words a person
+   * would actually search with. That prose is the bridge between a behavioural
+   * query ("what fraction of the repo made it into the output") and the code
+   * that implements it (`coverageScore(cwd, fileEntries, config)`), which shares
+   * not one token with the query.
+   *
+   * This text is added to the RETRIEVAL INDEX ONLY — never to the generated
+   * context file. The prompt artifact is token-budgeted and prose is expensive
+   * there; the index is not injected into any prompt, so it can afford the words
+   * that make a file findable.
+   *
+   * Zero-dependency, pure, bundle-safe.
+   */
+
+  // Enough to characterise a module without letting one verbose header dominate
+  // BM25 length normalisation for the whole corpus.
+  const MAX_CHARS = 400;
+  const MAX_SCAN_LINES = 60;
+
+  // Legal boilerplate is high-frequency noise: it appears in many files, shares no
+  // vocabulary with real queries, and would flatten idf across the corpus.
+  const BOILERPLATE = /\b(copyright|licensed under|SPDX-License|all rights reserved|permission is hereby granted)\b/i;
+
+  const BLOCK_LANGS = new Set(['js', 'jsx', 'ts', 'tsx', 'java', 'go', 'rs', 'kt', 'swift', 'scala', 'cs', 'php', 'dart', 'c', 'cpp', 'h']);
+  const HASH_LANGS = new Set(['py', 'rb', 'r', 'sh', 'yml', 'yaml', 'toml']);
+
+  function _extOf(filePath) {
+    const m = String(filePath).match(/\.([A-Za-z0-9]+)$/);
+    return m ? m[1].toLowerCase() : '';
+  }
+
+  /** Strip comment furniture, JSDoc tags, and markup from one raw comment line. */
+  function _cleanLine(line) {
+    return String(line)
+      .replace(/^\s*[/*#-]+\s?/, '')      // leading // /* * # ---
+      .replace(/\*+\/\s*$/, '')            // trailing */
+      .replace(/^\s*@\w+.*$/, '')          // @param / @returns tag lines
+      .replace(/[*_`]/g, '')               // markdown emphasis / code ticks
+      .trim();
+  }
+
+  /**
+   * Extract a module's leading documentation prose.
+   *
+   * @param {string} src       file contents
+   * @param {string} filePath  used only to pick a comment syntax
+   * @returns {string} collapsed prose, capped, or '' when there is none
+   */
+  function extractModuleDoc(src, filePath) {
+    if (!src || typeof src !== 'string') return '';
+    const ext = _extOf(filePath);
+    const lines = src.split('\n', MAX_SCAN_LINES);
+
+    const collected = [];
+    let inBlock = false;
+    let started = false;
+
+    for (const raw of lines) {
+      const line = raw.trim();
+      if (!started) {
+        // Skip preamble that precedes the real header comment.
+        if (!line) continue;
+        if (line.startsWith('#!')) continue;                       // shebang
+        if (/^['"]use strict['"];?$/.test(line)) continue;
+        if (/^(package|import|from|using|#include)\b/.test(line)) continue;
+      }
+
+      if (BLOCK_LANGS.has(ext) || ext === '') {
+        if (!inBlock && line.startsWith('/*')) { inBlock = true; started = true; }
+        if (inBlock) {
+          const cleaned = _cleanLine(line);
+          if (cleaned) collected.push(cleaned);
+          if (line.includes('*/')) break;
+          continue;
+        }
+        if (line.startsWith('//')) {                                // run of // lines
+          started = true;
+          const cleaned = _cleanLine(line);
+          if (cleaned) collected.push(cleaned);
+          continue;
+        }
+        if (started || collected.length) break;
+        break;                                                      // first real code — no header
+      }
+
+      if (HASH_LANGS.has(ext)) {
+        if (/^("""|''')/.test(line)) {                              // python docstring
+          started = true; inBlock = !inBlock;
+          const cleaned = _cleanLine(line.replace(/^("""|''')/, '').replace(/("""|''')$/, ''));
+          if (cleaned) collected.push(cleaned);
+          if (!inBlock) break;
+          continue;
+        }
+        if (inBlock) { const c = _cleanLine(line); if (c) collected.push(c); continue; }
+        if (line.startsWith('#')) { started = true; const c = _cleanLine(line); if (c) collected.push(c); continue; }
+        if (collected.length) break;
+        break;
+      }
+      break;
+    }
+
+    const text = collected.join(' ').replace(/\s+/g, ' ').trim();
+    if (!text || BOILERPLATE.test(text)) return '';
+    if (text.length <= MAX_CHARS) return text;
+    return text.slice(0, MAX_CHARS).replace(/\s+\S*$/, '');        // never cut mid-word
+  }
+
+  /** Render as an index-only pseudo-signature, or '' when there is no doc. */
+  function moduleDocSig(src, filePath) {
+    const doc = extractModuleDoc(src, filePath);
+    return doc ? `# module: ${doc}` : '';
+  }
+
+  module.exports = { extractModuleDoc, moduleDocSig, MAX_CHARS };
+  
+};
+
 // ── ./src/retrieval/ranker ──
 __factories["./src/retrieval/ranker"] = function(module, exports) {
   
@@ -16529,7 +16707,7 @@ __factories["./src/retrieval/ranker"] = function(module, exports) {
 
   const { loadWeights } = __require('./src/learning/weights');
   const { tokenize, STOP_WORDS } = __require('./src/retrieval/tokenizer');
-  const { bm25rank } = __require('./src/retrieval/bm25');
+  const { bm25rank, MODULE_DOC_RE } = __require('./src/retrieval/bm25');
 
   // ---------------------------------------------------------------------------
   // Default weights
@@ -16553,17 +16731,28 @@ __factories["./src/retrieval/ranker"] = function(module, exports) {
   // Max additive prior for import-graph centrality (opt-in retrieval.centralityBlend)
   const CENTRALITY_BLEND_WEIGHT = 0.3;
 
-  // Intent-specific weight adjustments
-  const INTENT_WEIGHTS = {
-    search:     DEFAULT_WEIGHTS,
-    debug:      { ...DEFAULT_WEIGHTS, exactToken: 1.2, pathMatch: 0.6 },
-    explain:    { ...DEFAULT_WEIGHTS, symbolMatch: 0.8, pathMatch: 0.9 },
-    refactor:   { ...DEFAULT_WEIGHTS, symbolMatch: 0.9, exactToken: 0.8 },
-    review:     { ...DEFAULT_WEIGHTS, pathMatch: 1.0, exactToken: 0.9 },
-    test:       { ...DEFAULT_WEIGHTS, exactToken: 0.7, symbolMatch: 0.4 },
-    integrate:  { ...DEFAULT_WEIGHTS, graphBoost: 0.7, pathMatch: 1.1 },
-    navigate:   { ...DEFAULT_WEIGHTS, pathMatch: 1.2, exactToken: 0.9 },
-  };
+  // Per-intent weight profiles were removed in favour of a single weight set.
+  // They were provably inert: scoreFile's score was discarded by rank(), so the
+  // profiles only ever reached the explain table. Once the signal WAS wired into
+  // the score (see SIGNAL_BLEND below), a sweep over the leak-free hard corpus
+  // showed intent-specific profiles produced byte-identical metrics to the flat
+  // DEFAULT_WEIGHTS at every blend value — so they earn nothing and are gone.
+  // `detectIntent` is retained: it is still reported to the user and is the right
+  // hook for shaping OUTPUT depth later.
+
+  // How much the weighted keyword/symbol/path signal modulates the BM25 base.
+  // Multiplicative and bounded, so it can only reorder files that already match —
+  // it can never lift a zero-BM25 file into the results. Tuned on the leak-free
+  // corpus: 0.5 gave hit@5 50.0% -> 56.7% and MRR 0.419 -> 0.447; higher values
+  // held hit@5 but degraded MRR.
+  const SIGNAL_BLEND = 0.5;
+
+  // TRIED AND REJECTED: a same-line co-occurrence bonus, on the theory that a file
+  // declaring `parseAuthToken` should outrank one mentioning `parseAuth` and
+  // `token` on separate lines. Swept 0.15-1.0: hit@5 did not move on either the
+  // 90-task authored corpus or the 32-task mined one, and MRR degraded
+  // monotonically as the weight rose. Signatures are short and dense enough that
+  // BM25's bag already captures this. Not reinstated without new evidence.
 
   // Penalty multipliers for negative signals
   const PENALTY_SIGNALS = {
@@ -16573,12 +16762,36 @@ __factories["./src/retrieval/ranker"] = function(module, exports) {
     nodeModules:   0.0,    // node_modules (zero score)
   };
 
-  function _computePenalty(filePath) {
+  // Query terms that mean the penalised category IS the target. Read from the
+  // query tokens directly, NOT via detectIntent: that classifier is first-match-
+  // wins over its pattern object, and `debug` precedes `test`, so "fix the failing
+  // test" classifies as debug and never reaches the test branch.
+  const WANTS_TESTS = new Set(['test', 'tests', 'spec', 'specs', 'unit', 'integration', 'e2e', 'assertion', 'assert', 'mock', 'fixture', 'coverage', 'testing']);
+  const WANTS_DOCS = new Set(['doc', 'docs', 'documentation', 'readme', 'changelog', 'guide', 'tutorial']);
+
+  /** Which penalised categories the query is explicitly asking for. */
+  function _queryWants(queryTokens) {
+    const wants = { tests: false, docs: false };
+    for (const t of queryTokens || []) {
+      if (WANTS_TESTS.has(t)) wants.tests = true;
+      if (WANTS_DOCS.has(t)) wants.docs = true;
+    }
+    return wants;
+  }
+
+  function _computePenalty(filePath, wants) {
     const pathLower = filePath.toLowerCase();
     if (pathLower.includes('node_modules')) return PENALTY_SIGNALS.nodeModules;
-    if (/(^|\/)(test|tests|spec|__tests__|e2e)($|\/)/.test(pathLower)) return PENALTY_SIGNALS.testFile;
+    // A penalty must never fire on the very thing the user asked for. Before
+    // this, "write tests for the ranker" multiplied every test file by 0.4 —
+    // the query and the penalty were pulling in opposite directions.
+    if (/(^|\/)(test|tests|spec|__tests__|e2e)($|\/)/.test(pathLower) || /\.(test|spec)\./.test(pathLower)) {
+      return (wants && wants.tests) ? 1.0 : PENALTY_SIGNALS.testFile;
+    }
     if (/(^|\/)(dist|build|\.next|\.nuxt|out|\.venv|venv)($|\/)/.test(pathLower)) return PENALTY_SIGNALS.generatedCode;
-    if (/(^|\/)(docs|doc|readme|changelog)($|\/)/.test(pathLower)) return PENALTY_SIGNALS.docsFile;
+    if (/(^|\/)(docs|doc|readme|changelog)($|\/)/.test(pathLower)) {
+      return (wants && wants.docs) ? 1.0 : PENALTY_SIGNALS.docsFile;
+    }
     return 1.0;
   }
 
@@ -16597,6 +16810,26 @@ __factories["./src/retrieval/ranker"] = function(module, exports) {
   }
 
   // Common utility paths that should be treated as hubs regardless of fanout
+  // The graph builders disagree on key case: src/graph/builder.js lowercases every
+  // node (normalizePath), while src/graph/call-graph.js keys by a case-preserving
+  // path.resolve. Assuming either one breaks the other, so every graph lookup in
+  // this file probes both forms — the same thing the centrality blend already does.
+  function _graphKeys(p) {
+    const norm = require('path').normalize(p);
+    const lower = norm.toLowerCase();
+    return lower === norm ? [norm] : [norm, lower];
+  }
+  function _graphGet(map, absPath) {
+    for (const k of _graphKeys(absPath)) {
+      const hit = map.get(k);
+      if (hit !== undefined) return hit;
+    }
+    return undefined;
+  }
+  function _registerKeys(map, absPath, value) {
+    for (const k of _graphKeys(absPath)) if (!map.has(k)) map.set(k, value);
+  }
+
   function _isHub(filePath) {
     return /\/(utils|helpers|shared|common|constants|types|interfaces|index|zzz|globals)\.(ts|tsx|js|jsx|r|R)$/.test(filePath)
         || filePath.endsWith('/index.ts') || filePath.endsWith('/index.js')
@@ -16612,14 +16845,18 @@ __factories["./src/retrieval/ranker"] = function(module, exports) {
    * @param {object}   weights
    * @returns {{ score: number, signals: { exactToken: number, symbolMatch: number, prefixMatch: number, pathMatch: number, penalty: number } }}
    */
-  function scoreFile(filePath, sigs, queryTokens, weights) {
+  function scoreFile(filePath, sigs, queryTokens, weights, wants) {
     if (!sigs || sigs.length === 0) return { score: 0, signals: { exactToken: 0, symbolMatch: 0, prefixMatch: 0, pathMatch: 0, penalty: 1.0 } };
 
     const w = weights || DEFAULT_WEIGHTS;
-    const signals = { exactToken: 0, symbolMatch: 0, prefixMatch: 0, pathMatch: 0, penalty: _computePenalty(filePath) };
+    const signals = { exactToken: 0, symbolMatch: 0, prefixMatch: 0, pathMatch: 0, penalty: _computePenalty(filePath, wants) };
 
-    // Build token set from all signatures
-    const sigText = sigs.join(' ');
+    // Module-doc prose is excluded here on purpose. This signal measures overlap
+    // with DECLARED IDENTIFIERS; prose relevance is BM25's job, where it is scored
+    // as its own weighted field. Letting descriptive text inflate the identifier
+    // signal double-counts it and measurably degraded MRR.
+    const codeSigs = sigs.filter((line) => !MODULE_DOC_RE.test(line));
+    const sigText = codeSigs.join(' ');
     const sigTokenSet = new Set(tokenize(sigText));
 
     // Build token set from the file path
@@ -16637,7 +16874,7 @@ __factories["./src/retrieval/ranker"] = function(module, exports) {
         signals.exactToken += bonus;
 
         // Bonus: appears directly in a function/class/method name line
-        const nameLineMatch = sigs.some((sig) => {
+        const nameLineMatch = codeSigs.some((sig) => {
           const nt = tokenize(sig.replace(/[^a-zA-Z0-9_\s]/g, ' '));
           return nt.includes(qt);
         });
@@ -16699,13 +16936,18 @@ __factories["./src/retrieval/ranker"] = function(module, exports) {
     const graph = (opts && opts.graph && opts.graph.forward instanceof Map) ? opts.graph : null;
     const cwd = (opts && opts.cwd) || null;
 
-    // Detect query intent and get appropriate weights
+    // Intent is reported to the user and shapes output depth; it no longer
+    // selects scoring weights (see SIGNAL_BLEND).
     const intent = detectIntent(query);
-    const intentWeights = INTENT_WEIGHTS[intent] || DEFAULT_WEIGHTS;
-    const weights = (opts && opts.weights) ? Object.assign({}, intentWeights, opts.weights) : intentWeights;
-    const learnedWeights = opts && opts.cwd ? loadWeights(opts.cwd) : null;
+    const weights = (opts && opts.weights) ? Object.assign({}, DEFAULT_WEIGHTS, opts.weights) : DEFAULT_WEIGHTS;
+    // Learned per-file multipliers are a LOCAL, evolving signal (.context/weights.json).
+    // Benchmarks and CI gates must opt out via { learned: false }, or a developer's
+    // local learned state silently changes the score and CI stops being reproducible.
+    const useLearned = !(opts && opts.learned === false);
+    const learnedWeights = opts && opts.cwd && useLearned ? loadWeights(opts.cwd) : null;
 
     const queryTokens = tokenize(query);
+    const queryWants = _queryWants(queryTokens);
     if (queryTokens.length === 0) {
       // Empty query: return top-K by file count (most signatures = most useful)
       const all = [];
@@ -16722,18 +16964,32 @@ __factories["./src/retrieval/ranker"] = function(module, exports) {
     // are matched. The existing negative-signal penalty and recency/graph/learned
     // boosts are layered on top; the per-token signals stay for the explain table.
     const bm25Scores = new Map();
-    for (const c of bm25rank(query, [...sigIndex.entries()].map(([file, sigs]) => ({ file, sigs })))) {
+    for (const c of bm25rank(query, [...sigIndex.entries()].map(([file, sigs]) => ({ file, sigs })), opts)) {
       bm25Scores.set(c.file, c.score);
     }
 
-    const scored = [];
+    // Two passes: scoreFile's weighted signal needs the max across the corpus to
+    // normalise against, so collect first, then combine.
+    const prescored = [];
+    let maxSignal = 0;
     for (const [file, sigs] of sigIndex.entries()) {
-      const result = scoreFile(file, sigs, queryTokens, weights);
+      const result = scoreFile(file, sigs, queryTokens, weights, queryWants);
+      if (result.score > maxSignal) maxSignal = result.score;
+      prescored.push({ file, sigs, result });
+    }
+
+    const scored = [];
+    for (const { file, sigs, result } of prescored) {
       const penalty = result.signals.penalty;
       const base = bm25Scores.get(file) || 0;
-      let score = base * penalty;
+      // Blend the weighted keyword/symbol/path signal into the BM25 base. This
+      // was previously computed and thrown away — `result.score` was never read,
+      // which silently made DEFAULT_WEIGHTS and every intent profile dead config.
+      const signalNorm = maxSignal > 0 ? result.score / maxSignal : 0;
+      let score = base * penalty * (1 + SIGNAL_BLEND * signalNorm);
       const signals = result.signals;
       signals.bm25 = base;
+      signals.signalBlend = signalNorm;
 
       // Recency boost
       if (recencySet && recencySet.has(file) && score > 0) {
@@ -16763,44 +17019,46 @@ __factories["./src/retrieval/ranker"] = function(module, exports) {
     // Hub suppression: files with high fanout (>20%) are not boosted
     if (graph && cwd) {
       const path = require('path');
-      // Build maps for relative ↔ absolute path conversion and index lookup
-      const relToIdx = new Map();
-      const absToRel = new Map();
+      // Every graph node is keyed by `path.normalize(p).toLowerCase()` (see
+      // normalizePath in src/graph/builder.js and src/graph/call-graph.js).
+      // Lookups MUST use the same key space: a bare path.resolve() preserves
+      // case, so on any repo whose absolute path contains an uppercase letter
+      // every .get() missed and this entire block was silently inert.
+      const keyToIdx = new Map();
       for (let i = 0; i < scored.length; i++) {
-        relToIdx.set(scored[i].file, i);
-        const abs = path.resolve(cwd, scored[i].file);
-        absToRel.set(abs, scored[i].file);
+        _registerKeys(keyToIdx, path.resolve(cwd, scored[i].file), i);
       }
 
       const hubs = _computeHubs(graph);
-      const hop1Files = new Set(); // track which files received hop1 boost
+      const hop1Files = new Set(); // normalised keys that received a hop1 boost
+      const hop1Seeds = [];        // original (un-normalised) paths, for hop-2 lookup
 
       // Hop 1: direct neighbors of scored files
       for (const entry of scored) {
         if (entry.score <= 0) continue;
-        const abs = path.resolve(cwd, entry.file);
-        const neighbors = graph.forward.get(abs) || [];
+        const neighbors = _graphGet(graph.forward, path.resolve(cwd, entry.file)) || [];
         for (const neighborAbs of neighbors) {
-          if (_isHub(neighborAbs) || hubs.has(neighborAbs)) continue;
-          const neighborRel = path.relative(cwd, neighborAbs).replace(/\\/g, '/');
-          const idx = relToIdx.get(neighborRel);
+          const nk = path.normalize(neighborAbs);
+          if (_isHub(nk) || hubs.has(nk) || hubs.has(nk.toLowerCase())) continue;
+          const idx = _graphGet(keyToIdx, nk);
           if (idx !== undefined) {
             scored[idx].score += GRAPH_BOOST_AMOUNTS.hop1;
             scored[idx].signals.graphBoost = (scored[idx].signals.graphBoost || 0) + GRAPH_BOOST_AMOUNTS.hop1;
-            hop1Files.add(neighborAbs);
+            hop1Files.add(nk);
+            hop1Seeds.push(neighborAbs);
           }
         }
       }
 
       // Hop 2: neighbors of hop1 files (only if they didn't get a direct score)
-      for (const hop1File of hop1Files) {
-        if (!absToRel.has(hop1File)) continue; // skip files not in index
-        const neighbors = graph.forward.get(hop1File) || [];
+      for (const hop1Key of hop1Seeds) {
+        if (_graphGet(keyToIdx, hop1Key) === undefined) continue; // skip files not in index
+        const neighbors = _graphGet(graph.forward, hop1Key) || [];
         for (const neighborAbs of neighbors) {
-          if (_isHub(neighborAbs) || hubs.has(neighborAbs)) continue;
-          if (hop1Files.has(neighborAbs)) continue; // skip already hop1-boosted
-          const neighborRel = path.relative(cwd, neighborAbs).replace(/\\/g, '/');
-          const idx = relToIdx.get(neighborRel);
+          const nk = path.normalize(neighborAbs);
+          if (_isHub(nk) || hubs.has(nk) || hubs.has(nk.toLowerCase())) continue;
+          if (hop1Files.has(nk)) continue; // skip already hop1-boosted
+          const idx = _graphGet(keyToIdx, nk);
           if (idx !== undefined && scored[idx].score > 0) {
             // Only boost files that have some baseline score (not noise)
             scored[idx].score += GRAPH_BOOST_AMOUNTS.hop2;
@@ -16817,16 +17075,17 @@ __factories["./src/retrieval/ranker"] = function(module, exports) {
     const callGraph = (opts && opts.callGraph && opts.callGraph.forward instanceof Map) ? opts.callGraph : null;
     if (callGraph && cwd) {
       const path = require('path');
-      const relToIdx = new Map();
-      for (let i = 0; i < scored.length; i++) relToIdx.set(scored[i].file, i);
+      // buildCallFileGraph keys by a CASE-PRESERVING path.resolve, unlike the
+      // import graph builder which lowercases — hence the dual-form probe.
+      const keyToIdx = new Map();
+      for (let i = 0; i < scored.length; i++) _registerKeys(keyToIdx, path.resolve(cwd, scored[i].file), i);
       const hubs = _computeHubs(callGraph);
       const seeds = scored.filter((e) => e.score > 0).map((e) => e.file);
       for (const file of seeds) {
-        const abs = path.resolve(cwd, file);
-        for (const neighborAbs of (callGraph.forward.get(abs) || [])) {
-          if (_isHub(neighborAbs) || hubs.has(neighborAbs)) continue;
-          const neighborRel = path.relative(cwd, neighborAbs).replace(/\\/g, '/');
-          const idx = relToIdx.get(neighborRel);
+        for (const neighborAbs of (_graphGet(callGraph.forward, path.resolve(cwd, file)) || [])) {
+          const nk = path.normalize(neighborAbs);
+          if (_isHub(nk) || hubs.has(nk) || hubs.has(nk.toLowerCase())) continue;
+          const idx = _graphGet(keyToIdx, nk);
           if (idx !== undefined && scored[idx].file !== file) {
             scored[idx].score += GRAPH_BOOST_AMOUNTS.callHop;
             scored[idx].signals.callGraphBoost = (scored[idx].signals.callGraphBoost || 0) + GRAPH_BOOST_AMOUNTS.callHop;
@@ -17000,6 +17259,18 @@ __factories["./src/retrieval/ranker"] = function(module, exports) {
       }
     } catch (_) {}
     _mergeSigIndex(index, _buildSigIndexFromCache(cwd));
+
+    // The complete retrieval index (written by generate before applyTokenBudget)
+    // takes precedence: it is the only source containing files the budget dropped,
+    // and full signatures for files the budget collapsed to line anchors. It is
+    // merged as the BASE rather than on top because _mergeSigIndex only replaces
+    // when the source has MORE signatures — a collapsed entry has the same count
+    // as its full form, so merging the other way would keep the anchors.
+    try {
+      const full = __require('./src/retrieval/sig-index-store').readFullIndex(cwd);
+      if (full.size > 0) return _mergeSigIndex(full, index);
+    } catch (_) { /* absent → budgeted view is still served */ }
+
     return index;
   }
 
@@ -17125,25 +17396,155 @@ __factories["./src/retrieval/ranker"] = function(module, exports) {
   // ---------------------------------------------------------------------------
   // Intent detection — 7 intents
   // ---------------------------------------------------------------------------
+  // Nouns carry an optional plural: `\btest\b` does not match "tests", so
+  // "write unit tests for the ranker" matched NO intent at all and fell through
+  // to the 'search' default.
   const INTENT_PATTERNS = {
-    debug:    /\b(bug|fix|error|crash|exception|broken|failing|issue|problem|regression)\b/i,
+    debug:    /\b(bugs?|fix(es|ed)?|errors?|crash(es)?|exceptions?|broken|failing|failures?|issues?|problems?|regressions?)\b/i,
     explain:  /\b(explain|how does|what is|understand|overview|architecture|describe|walk me|teach)\b/i,
-    refactor: /\b(refactor|restructure|redesign|clean up|extract|move|rename|simplify|optimize)\b/i,
+    refactor: /\b(refactor|restructure|redesign|clean up|extract|move|rename|simplify|optimi[sz]e)\b/i,
     review:   /\b(review|check|audit|security|pr|pull request|assess|validate)\b/i,
-    test:     /\b(test|unit test|integration test|testing|spec|assert|mock)\b/i,
-    integrate:/\b(import|integrate|connect|wire|bind|require|export|depend|graph)\b|require[ds]\b/i,
+    test:     /\b(tests?|unit tests?|integration tests?|testing|specs?|assert(ion)?s?|mocks?|fixtures?)\b/i,
+    integrate:/\b(imports?|integrate|connect|wire|bind|requires?|exports?|depends?|dependenc(y|ies)|graph)\b/i,
     navigate: /\b(find|locate|where|search|look for|show me|navigate|browse|list)\b/i,
   };
 
-  function detectIntent(query) {
-    if (!query || typeof query !== 'string') return 'search';
+  /**
+   * Every intent whose pattern matches, strongest first.
+   *
+   * A real request is routinely multi-intent — "fix the failing test" is both a
+   * debug task and a test task — and reporting one label discards that. Worse,
+   * the single-label version returned the FIRST key in INTENT_PATTERNS order, so
+   * `debug` permanently shadowed `test`: no query containing "fix" or "failing"
+   * could ever be labelled a test, no matter how test-shaped it was.
+   *
+   * Ranked by how many distinct terms each pattern matched, so the dominant
+   * intent leads; ties fall back to declaration order for determinism.
+   *
+   * @param {string} query
+   * @returns {string[]} matched intents, never empty (defaults to ['search'])
+   */
+  function detectIntents(query) {
+    if (!query || typeof query !== 'string') return ['search'];
+    const scored = [];
+    let order = 0;
     for (const [intent, re] of Object.entries(INTENT_PATTERNS)) {
-      if (re.test(query)) return intent;
+      const hits = query.match(new RegExp(re.source, re.flags.includes('g') ? re.flags : re.flags + 'g'));
+      if (hits && hits.length) {
+        scored.push({ intent, hits: new Set(hits.map((h) => h.toLowerCase())).size, order: order });
+      }
+      order++;
     }
-    return 'search';
+    if (scored.length === 0) return ['search'];
+    scored.sort((a, b) => (b.hits - a.hits) || (a.order - b.order));
+    return scored.map((s) => s.intent);
   }
 
-  module.exports = { rank, buildSigIndex, scoreFile, formatRankTable, formatRankJSON, DEFAULT_WEIGHTS, GRAPH_BOOST_AMOUNTS, CENTRALITY_BLEND_WEIGHT, detectIntent };
+  /** Primary intent. Kept for callers that want a single label. */
+  function detectIntent(query) {
+    return detectIntents(query)[0];
+  }
+
+  module.exports = { rank, buildSigIndex, scoreFile, _queryWants, detectIntents, formatRankTable, formatRankJSON, DEFAULT_WEIGHTS, GRAPH_BOOST_AMOUNTS, CENTRALITY_BLEND_WEIGHT, detectIntent };
+  
+};
+
+// ── ./src/retrieval/sig-index-store ──
+__factories["./src/retrieval/sig-index-store"] = function(module, exports) {
+  
+  /**
+   * Complete, unbudgeted signature index for retrieval.
+   *
+   * WHY THIS EXISTS
+   * ---------------
+   * The generated context file (CLAUDE.md / AGENTS.md / copilot-instructions.md)
+   * is a BUDGETED VIEW: `applyTokenBudget` drops and collapses files so the
+   * artifact stays under `maxTokens`, because it is injected into every prompt.
+   *
+   * `buildSigIndex` used to parse that same artifact to build the ranker's index,
+   * so retrieval inherited the prompt budget. Every file the budget dropped became
+   * permanently unreachable by `sigmap ask` — no ranking change can surface a file
+   * that is not in the index. On this repo that was 53 of 155 source files (34%),
+   * and restoring them moved hit@5 from 50% to 90% on the retrieval corpus.
+   *
+   * The two artifacts have opposite requirements — the prompt file wants to be
+   * small, the index wants to be complete — so they are now separate. This store
+   * is written by `generate` BEFORE the budget is applied, and lives under
+   * `.context/` (gitignored, never injected into a prompt).
+   *
+   * Zero-dependency, bundle-safe (fs + path only).
+   */
+
+  const fs = require('fs');
+  const path = require('path');
+
+  const INDEX_DIR = '.context';
+  const INDEX_FILE = 'sig-index.json';
+  const SCHEMA = 1;
+
+  /** Absolute path to the retrieval index artifact. */
+  function indexPath(cwd) {
+    return path.join(cwd, INDEX_DIR, INDEX_FILE);
+  }
+
+  /**
+   * Persist the complete signature index.
+   *
+   * @param {string} cwd
+   * @param {Array<{filePath: string, sigs: string[]}>} fileEntries - every
+   *        extracted entry, BEFORE applyTokenBudget has dropped or collapsed any.
+   * @param {{ version?: string }} [opts]
+   * @returns {{ path: string, files: number }}
+   */
+  function writeFullIndex(cwd, fileEntries, opts = {}) {
+    const files = {};
+    let count = 0;
+    for (const e of fileEntries || []) {
+      if (!e || !e.filePath || !Array.isArray(e.sigs) || e.sigs.length === 0) continue;
+      const rel = path.relative(cwd, e.filePath).replace(/\\/g, '/');
+      if (!rel || rel.startsWith('..')) continue;
+      files[rel] = e.sigs;
+      count++;
+    }
+
+    const out = indexPath(cwd);
+    fs.mkdirSync(path.dirname(out), { recursive: true });
+    // Write-then-rename so a concurrent `ask` never observes a half-written index.
+    const tmp = `${out}.tmp`;
+    fs.writeFileSync(tmp, JSON.stringify({
+      schema: SCHEMA,
+      sigmapVersion: opts.version || null,
+      generated: new Date().toISOString(),
+      files,
+    }), 'utf8');
+    fs.renameSync(tmp, out);
+    return { path: out, files: count };
+  }
+
+  /**
+   * Load the complete signature index, or an empty Map when absent/unreadable.
+   *
+   * Deliberately NOT version-busted (unlike .sigmap-cache.json): a stale but
+   * complete index still retrieves the right files, whereas discarding it drops
+   * retrieval back to the budgeted view — the exact failure this store exists to
+   * prevent. Staleness is handled by re-running generate or by cache/freshen.
+   *
+   * @param {string} cwd
+   * @returns {Map<string, string[]>}
+   */
+  function readFullIndex(cwd) {
+    const index = new Map();
+    try {
+      const data = JSON.parse(fs.readFileSync(indexPath(cwd), 'utf8'));
+      if (!data || data.schema !== SCHEMA || !data.files) return index;
+      for (const [rel, sigs] of Object.entries(data.files)) {
+        if (Array.isArray(sigs) && sigs.length > 0) index.set(rel, sigs);
+      }
+    } catch (_) { /* absent or corrupt → caller falls back to the context file */ }
+    return index;
+  }
+
+  module.exports = { writeFullIndex, readFullIndex, indexPath, SCHEMA, INDEX_FILE };
   
 };
 
@@ -21372,8 +21773,68 @@ function buildFileList(cwd, config) {
     const found = walkDir(abs, config.exclude, config.maxDepth);
     files.push(...found);
   }
+  files.push(...declaredEntrypoints(cwd, config, files));
   // Deduplicate
   return [...new Set(files)];
+}
+
+/**
+ * Source files a project declares as its own entrypoints in package.json
+ * (`main` and every `bin` target), when they live outside srcDirs.
+ *
+ * A CLI's entrypoint is usually at the repo root, so a srcDirs of [src] left
+ * it unindexed and therefore unreachable by `sigmap ask` — on this repo that
+ * was gen-context.js, which holds the whole generator pipeline. Declared
+ * entrypoints are load-bearing by definition, so they are always scanned.
+ */
+function collectTestEntries(cwd, config, existing) {
+  const TEST_ROOTS = ['test', 'tests', '__tests__', 'spec', 'e2e'];
+  const have = new Set((existing || []).map((e) => e.filePath));
+  const out = [];
+  let moduleDocSig = null;
+  try { ({ moduleDocSig } = requireSourceOrBundled('./src/retrieval/module-doc')); } catch (_) {}
+  for (const root of TEST_ROOTS) {
+    const abs = path.join(cwd, root);
+    if (!fs.existsSync(abs)) continue;
+    let files = [];
+    try { files = walkDir(abs, config.exclude, config.maxDepth); } catch (_) { continue; }
+    for (const fp of files) {
+      if (have.has(fp)) continue;
+      let src = '';
+      try { src = fs.readFileSync(fp, 'utf8'); } catch (_) { continue; }
+      let sigs = [];
+      try {
+        const { extractFile } = requireSourceOrBundled('./src/extractors/dispatch');
+        sigs = extractFile(fp, src) || [];
+      } catch (_) { continue; }
+      if (!sigs.length) continue;
+      const doc = moduleDocSig ? moduleDocSig(src, fp) : '';
+      out.push({ filePath: fp, sigs: doc ? [doc, ...sigs] : sigs });
+    }
+  }
+  return out;
+}
+
+function declaredEntrypoints(cwd, config, existing) {
+  const out = [];
+  try {
+    const pkg = JSON.parse(fs.readFileSync(path.join(cwd, 'package.json'), 'utf8'));
+    const have = new Set(existing);
+    const refs = [];
+    if (typeof pkg.main === 'string') refs.push(pkg.main);
+    if (typeof pkg.bin === 'string') refs.push(pkg.bin);
+    else if (pkg.bin && typeof pkg.bin === 'object') refs.push(...Object.values(pkg.bin).filter((v) => typeof v === 'string'));
+    for (const ref of refs) {
+      const abs = path.resolve(cwd, ref);
+      if (have.has(abs) || out.includes(abs)) continue;
+      const rel = path.relative(cwd, abs);
+      if (!rel || rel.startsWith('..')) continue;                       // outside the repo
+      if ((config.exclude || []).some((x) => rel.split(path.sep).includes(x))) continue;
+      if (!fs.existsSync(abs) || !fs.statSync(abs).isFile()) continue;
+      out.push(abs);
+    }
+  } catch (_) { /* no package.json, or unreadable → nothing to add */ }
+  return out;
 }
 
 // ---------------------------------------------------------------------------
@@ -22647,6 +23108,60 @@ function runGenerate(cwd, config, reportMode, reportJson = false) {
 
   let result;
   if (!reportMode) {
+    // Retrieval index (complete, unbudgeted) — written BEFORE applyTokenBudget
+    // and before the strategy split, so it holds every extracted file for every
+    // strategy. The generated context file is a budgeted VIEW for prompt
+    // injection; the ranker must not inherit that budget or files dropped to fit
+    // maxTokens become permanently unreachable by `sigmap ask`.
+    try {
+      const __store = requireSourceOrBundled('./src/retrieval/sig-index-store');
+      // Honour --terse: `sigmap ask` renders .context/query-context.md straight
+      // from these signatures, and that IS prompt-bound, so the user's format
+      // choice has to survive into the index. Terse encoding preserves line
+      // anchors byte-exactly, so get_lines still resolves.
+      // Index-only enrichment: a module's leading comment describes its PURPOSE
+      // in prose, which is the vocabulary a behavioural query actually uses.
+      // Signatures carry shape, not intent — `coverageScore(cwd, fileEntries, config)`
+      // shares no token with "what fraction of the repo made it into the output",
+      // but that file's header says exactly that. Added to the retrieval index
+      // ONLY: the prompt artifact is token-budgeted, the index is not.
+      let __entries = fileEntries;
+      try {
+        // TRIED AND REJECTED: also indexing every per-symbol doc sentence
+        // untruncated (src/retrieval/doc-text.js). 39% of extractor doc hints are
+        // cut at 60 chars, so recovering them looked like free vocabulary. It is
+        // not: train hit@5 fell 75.6% -> 73.3% at every docWeight from 0.2 to 1.0,
+        // and the mined corpus never moved off 62.5%. The MODULE HEADER is the
+        // high-signal prose — it states the file's purpose. Per-symbol sentences
+        // describe internal helpers, so they broaden what each file matches
+        // without making any file a better answer.
+        const { moduleDocSig } = requireSourceOrBundled('./src/retrieval/module-doc');
+        __entries = __entries.map((e) => {
+          let src = e.content;
+          if (typeof src !== 'string') { try { src = fs.readFileSync(e.filePath, 'utf8'); } catch (_) { src = ''; } }
+          const doc = moduleDocSig(src, e.filePath);
+          return doc ? Object.assign({}, e, { sigs: [doc, ...e.sigs] }) : e;
+        });
+      } catch (_) { /* enrichment is best-effort */ }
+      if (config && config.terse) {
+        try {
+          const { encodeTerseSigs } = requireSourceOrBundled('./src/format/terse');
+          __entries = fileEntries.map((e) => Object.assign({}, e, { sigs: encodeTerseSigs(e.sigs) }));
+        } catch (_) { /* terse unavailable → index full signatures */ }
+      }
+      // Test files: indexed, never rendered into the prompt. They were the one
+      // whole category `sigmap ask` could not reach at all — srcDirs excludes
+      // them, so "where are the tests for X" had no answer at any rank. The
+      // prompt artifact stays clean because this list never reaches formatOutput.
+      try {
+        __entries = __entries.concat(collectTestEntries(cwd, config, __entries));
+      } catch (_) { /* best-effort */ }
+      const __w = __store.writeFullIndex(cwd, __entries, { version: VERSION });
+      if (process.argv.includes('--verbose')) {
+        console.warn(`[sigmap] retrieval index: ${__w.files} file(s) → ${path.relative(cwd, __w.path)}`);
+      }
+    } catch (_) { /* non-fatal: ranker falls back to parsing the context file */ }
+
     if (strategy === 'per-module') {
       result = runPerModuleStrategy(cwd, configWithBudget, fileEntries, inputTokenTotal);
     } else if (strategy === 'hot-cold') {
@@ -23333,14 +23848,12 @@ function getRawTokenCount(cwd, config) {
   return total;
 }
 
-function getIntentWeights(intent) {
+// Intent no longer selects scoring weights — the per-intent multipliers were
+// measured to have zero effect on ranking (see src/retrieval/ranker.js).
+// Kept as a single call site so the ask handler keeps one weights source.
+function getIntentWeights(_intent) {
   const { DEFAULT_WEIGHTS } = requireSourceOrBundled('./src/retrieval/ranker');
-  const base = Object.assign({}, DEFAULT_WEIGHTS);
-  if (intent === 'debug')    return Object.assign({}, base, { recencyBoost: base.recencyBoost * 1.5 });
-  if (intent === 'explain')  return Object.assign({}, base, { symbolMatch:  base.symbolMatch  * 1.5 });
-  if (intent === 'refactor') return Object.assign({}, base, { pathMatch:    base.pathMatch    * 1.5 });
-  if (intent === 'review')   return Object.assign({}, base, { exactToken:   base.exactToken   * 1.3 });
-  return base;
+  return Object.assign({}, DEFAULT_WEIGHTS);
 }
 
 function extractQuerySymbols(query) {
@@ -23515,7 +24028,7 @@ function main() {
       process.exit(1);
     }
 
-    const { detectIntent, buildSigIndex, rank } = requireSourceOrBundled('./src/retrieval/ranker');
+    const { detectIntent, detectIntents, buildSigIndex, rank } = requireSourceOrBundled('./src/retrieval/ranker');
     const { coverageScore } = requireSourceOrBundled('./src/analysis/coverage-score');
     const { loadSession, saveSession, mergeSessionContext } = requireSourceOrBundled('./src/session/memory');
     const { detectWorkspaces, inferPackage, scopeToPackage } = requireSourceOrBundled('./src/workspace/detector');
@@ -23692,7 +24205,7 @@ function main() {
       console.log([
         bar,
         ` sigmap ask  "${query}"`,
-        ` Intent    : ${intent}`,
+        ` Intent    : ${detectIntents(query).join(', ')}`,
         ` Context   : ${ctxTok.toLocaleString()} tokens  →  ${path.relative(cwd, outPath)}`,
         ` Coverage  : ${coveragePct}%`,
         ` Risk      : ${riskLevel}`,

--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
   },
   "scripts": {
     "test": "node test/run.js && node test/r-language.test.js",
-    "test:integration": "node test/integration/strategy.test.js && node test/integration/secret-scan.test.js && node test/integration/token-budget.test.js && node test/integration/auto-budget.test.js && node test/integration/mcp/server.test.js && node test/integration/verify-ai-output.test.js && node test/integration/memory-tools.test.js && node test/integration/squeeze.test.js && node test/integration/context-consistency.test.js && node test/integration/features/llms-current.test.js",
+    "test:integration": "node test/integration/all.js",
     "test:integration:all": "node test/integration/all.js",
     "test:python": "python3 test/test_python_ast_extractor.py",
     "test:all": "node test/run.js && node test/r-language.test.js && node test/integration/strategy.test.js && node test/integration/secret-scan.test.js",
@@ -53,7 +53,9 @@
     "prepublishOnly": "node scripts/check-bundle.mjs && node scripts/build-bundle.mjs --check && node scripts/gen-benchmark-latest.mjs --check && node scripts/check-version-meta.mjs && node scripts/sync-metrics.mjs --check && node scripts/generate-llms.mjs",
     "benchmark:grounding": "node scripts/run-hallucination-benchmark.mjs",
     "benchmark:honest": "node scripts/run-honest-benchmark.mjs --save",
-    "benchmark:llm-ablation": "node scripts/run-llm-ablation.mjs"
+    "benchmark:llm-ablation": "node scripts/run-llm-ablation.mjs",
+    "benchmark:retrieval": "node scripts/run-retrieval-gate.mjs",
+    "validate:retrieval": "node scripts/check-corpus.mjs && node scripts/check-corpus.mjs benchmarks/tasks/retrieval-mined.jsonl && node scripts/run-retrieval-gate.mjs --gate --no-regress"
   },
   "files": [
     "gen-context.js",

--- a/scripts/check-corpus.mjs
+++ b/scripts/check-corpus.mjs
@@ -1,0 +1,69 @@
+#!/usr/bin/env node
+/**
+ * Retrieval-corpus hygiene.
+ *
+ * `queryLeakage` catches BASENAME leakage — a query containing its answer's
+ * filename. Once module-doc prose is indexed, a second, subtler leak appears:
+ * a query paraphrased straight from the file's own header is trivially
+ * retrievable for reasons that have nothing to do with ranking quality.
+ *
+ * So this also checks VERBATIM OVERLAP: no 4-word run from a query may appear
+ * in its expected file's indexed text. Shared vocabulary is legitimate and
+ * necessary — BM25 cannot work without it. Copied phrasing is not.
+ */
+import { readFileSync } from 'fs';
+import { join, dirname } from 'path';
+import { fileURLToPath } from 'url';
+import { createRequire } from 'module';
+
+const ROOT = join(dirname(fileURLToPath(import.meta.url)), '..');
+const require = createRequire(import.meta.url);
+const { queryLeakage } = require(join(ROOT, 'src/eval/corpus'));
+const { readFullIndex } = require(join(ROOT, 'src/retrieval/sig-index-store'));
+
+const NGRAM = 4;
+const file = process.argv[2] || 'benchmarks/tasks/retrieval-hard.jsonl';
+const tasks = readFileSync(join(ROOT, file), 'utf8').split('\n').filter(Boolean).map((l) => JSON.parse(l));
+const index = readFullIndex(ROOT);
+
+const norm = (s) => String(s).toLowerCase().replace(/[^a-z0-9 ]+/g, ' ').replace(/\s+/g, ' ').trim();
+function ngrams(text, n) {
+  const w = norm(text).split(' ').filter(Boolean);
+  const out = [];
+  for (let i = 0; i + n <= w.length; i++) out.push(w.slice(i, i + n).join(' '));
+  return out;
+}
+
+let basenameLeaks = 0, verbatimLeaks = 0, missing = 0, unreachable = 0;
+const problems = [];
+for (const t of tasks) {
+  const bl = queryLeakage(t.query, t.expected_files);
+  if (!bl.clean) { basenameLeaks++; problems.push(`${t.id}  BASENAME LEAK ${JSON.stringify(bl.leaked)}`); }
+  for (const f of t.expected_files) {
+    if (!index.has(f)) {
+      missing++;
+      problems.push(`${t.id}  EXPECTED FILE NOT INDEXED: ${f}`);
+      continue;
+    }
+    const hay = norm(index.get(f).join(' '));
+    const hit = ngrams(t.query, NGRAM).find((g) => hay.includes(g));
+    if (hit) { verbatimLeaks++; problems.push(`${t.id}  VERBATIM ${NGRAM}-GRAM in ${f}: "${hit}"`); }
+  }
+}
+
+// A task nothing can retrieve is not "hard", it is broken.
+const ids = new Set(tasks.map((t) => t.id));
+if (ids.size !== tasks.length) problems.push(`DUPLICATE task ids (${tasks.length - ids.size})`);
+
+console.log(`\ncorpus: ${file}`);
+console.log(`  tasks             : ${tasks.length}`);
+console.log(`  basename leaks    : ${basenameLeaks}`);
+console.log(`  verbatim ${NGRAM}-grams : ${verbatimLeaks}`);
+console.log(`  expected missing  : ${missing}`);
+if (problems.length) {
+  console.log('\nproblems:');
+  for (const p of problems) console.log('  ✗ ' + p);
+  console.log('');
+  process.exit(1);
+}
+console.log('  ✓ clean\n');

--- a/scripts/mine-corpus.mjs
+++ b/scripts/mine-corpus.mjs
@@ -1,0 +1,159 @@
+#!/usr/bin/env node
+/**
+ * Mine a retrieval corpus from git history.
+ *
+ * WHY: every hand-authored task carries its author's bias. Tasks written after
+ * reading the indexed module docs score ~20pp above tasks written before — the
+ * verbatim-ngram check catches copied phrasing, not shared concepts. The only
+ * real fix is an author who never saw the index.
+ *
+ * Git history is full of them. A commit subject is a developer stating intent
+ * in their own words; the files that commit touched are ground truth. Neither
+ * is produced by whoever is tuning the ranker.
+ *
+ * RULES
+ *  - Focused commits only (1-3 source files, <= 8 files total): a 40-file
+ *    refactor has no single correct answer.
+ *  - Conventional-commit furniture is stripped so the query reads as a request.
+ *  - A leaking query is DROPPED, never rewritten. Editing it to pass would put
+ *    the tuner's words back in and defeat the entire point.
+ *  - Expected files must still exist in today's index.
+ *  - At most 2 tasks per file, so one hot file cannot dominate the corpus.
+ *
+ * PARAMETER SENSITIVITY — read before trusting any single number. This repo's
+ * 960 commits yield only ~23 usable tasks, so one task is 4.3pp. Sweeping the
+ * defensible parameter range (MIN_SHARE 0.10-0.25, per-file cap 5-12) moves
+ * hit@5 across 53.3%-73.1%. Loosening the cap to admit MORE tasks lowers the
+ * score, which means the small-corpus figures are optimistic, not pessimistic.
+ * Defaults below are chosen for the least-skewed corpus (fewest repeats per
+ * file), NOT the highest score. Treat the output as a band, not a point.
+ *
+ * Usage: node scripts/mine-corpus.mjs [--limit 960] [--out <file>]
+ */
+import { execFileSync } from 'child_process';
+import { writeFileSync } from 'fs';
+import { join, dirname } from 'path';
+import { fileURLToPath } from 'url';
+import { createRequire } from 'module';
+
+const ROOT = join(dirname(fileURLToPath(import.meta.url)), '..');
+const require = createRequire(import.meta.url);
+const { queryLeakage } = require(join(ROOT, 'src/eval/corpus'));
+const { readFullIndex } = require(join(ROOT, 'src/retrieval/sig-index-store'));
+
+const argv = process.argv.slice(2);
+const val = (f, d) => { const i = argv.indexOf(f); return i !== -1 && argv[i + 1] ? argv[i + 1] : d; };
+const LIMIT = parseInt(val('--limit', '960'), 10);
+const OUT = val('--out', 'benchmarks/tasks/retrieval-mined.jsonl');
+
+const git = (args) => execFileSync('git', args, { cwd: ROOT, encoding: 'utf8', maxBuffer: 1 << 26 });
+const index = readFullIndex(ROOT);
+
+/** Strip conventional-commit furniture so the subject reads as a request. */
+function cleanSubject(s) {
+  return String(s)
+    .replace(/^\s*\w+(\([^)]*\))?!?:\s*/, '')
+    .replace(/\((closes|fixes|refs)[^)]*\)/gi, '')
+    .replace(/#\d+/g, '')
+    .replace(/\bv?\d+\.\d+\.\d+\b/g, '')
+    .replace(/`[^`]*`/g, ' ')
+    .replace(/\b[\w./-]+\.(js|ts|py|mjs|json|md)\b/g, ' ')
+    .replace(/\(\s*\)/g, ' ')                      // empty parens left by the strips above
+    .replace(/[—–-]\s*$/, '')
+    .replace(/^\s*[—–-]\s*/, '')
+    .replace(/\s+/g, ' ')
+    .trim();
+}
+
+/**
+ * Reject subjects that are not a statement of intent: merge-branch names
+ * ("Feat/output flag"), bare version bumps, and changelog fragments that are
+ * just a list of feature names joined by "+".
+ */
+function isUsableSubject(q) {
+  if (/^\w+\/[\w-]+/.test(q)) return false;            // Feat/output-flag
+  if ((q.match(/\+/g) || []).length >= 2) return false;  // "a + b + c" changelog line
+  if (!/[a-z]{3}\s+[a-z]{2}/i.test(q)) return false;     // no prose-like word run
+  return true;
+}
+
+const norm = (s) => String(s).toLowerCase().replace(/[^a-z0-9 ]+/g, ' ').replace(/\s+/g, ' ').trim();
+function verbatimHit(query, files) {
+  const w = norm(query).split(' ').filter(Boolean);
+  for (const f of files) {
+    const hay = norm((index.get(f) || []).join(' '));
+    for (let i = 0; i + 4 <= w.length; i++) if (hay.includes(w.slice(i, i + 4).join(' '))) return true;
+  }
+  return false;
+}
+
+const log = git(['log', '--format=%H %s', `-n${LIMIT}`]).split('\n').filter(Boolean);
+const tasks = [];
+const seenFile = new Map();
+const seenQuery = new Set();
+const stats = { scanned: 0, unfocused: 0, tooShort: 0, notIndexed: 0, leaked: 0, verbatim: 0, dupe: 0 };
+
+for (const line of log) {
+  const sha = line.slice(0, 40);
+  const subject = line.slice(41).trim();
+  if (!/^[0-9a-f]{40}$/.test(sha) || !subject) continue;
+  stats.scanned++;
+  if (/^merge\b/i.test(subject) || /^(chore|docs|ci|build|style)\b/i.test(subject)) { stats.unfocused++; continue; }
+
+  // --numstat, not --name-only: a commit's changed-file list mixes the file the
+  // work happened in with collateral edits (a config default, a re-export). Both
+  // look identical by name. Labelling collateral as "the answer" is simply wrong
+  // ground truth — "add MiniMax ablation provider" touched pricing.js for 2 lines
+  // out of 37, while the real work sat in a script. Share of changed lines
+  // separates them mechanically, with no judgement from whoever is tuning.
+  let stat;
+  try { stat = git(['show', '--numstat', '--format=', '--no-renames', sha]); }
+  catch { continue; }
+  const churn = new Map();
+  for (const row of stat.split('\n')) {
+    const m = row.match(/^(\d+|-)\t(\d+|-)\t(.+)$/);
+    if (!m) continue;
+    const add = m[1] === '-' ? 0 : parseInt(m[1], 10);
+    const del = m[2] === '-' ? 0 : parseInt(m[2], 10);
+    churn.set(m[3], add + del);
+  }
+  const files = [...churn.keys()];
+  const totalChurn = [...churn.values()].reduce((x, y) => x + y, 0) || 1;
+  // MIN_SHARE drops collateral. gen-context.js is additionally required to be
+  // the DOMINANT file: build-bundle rewrites it on nearly every src change, so
+  // a small diff there is regeneration noise, while a large one is real work in
+  // its hand-written half (it holds the whole generator pipeline).
+  const MIN_SHARE = 0.25;
+  const maxChurn = Math.max(...churn.values(), 0);
+  const src = files.filter((f) => {
+    if (!/\.(js|py)$/.test(f)) return false;
+    if (!/^(src|packages)\//.test(f) && f.includes('/')) return false;
+    const share = (churn.get(f) || 0) / totalChurn;
+    if (f === 'gen-context.js') return churn.get(f) === maxChurn && share >= MIN_SHARE;
+    return share >= MIN_SHARE;
+  });
+  // No file-count ceiling. It used to reject any commit touching >4 source
+  // files, on the theory that a broad change has no single right answer — but
+  // MIN_SHARE already isolates the file the work actually happened in, so the
+  // ceiling was just discarding usable history. 850 of 960 commits were being
+  // dropped here, which is why the corpus was too small to give a stable number.
+  if (src.length < 1) { stats.unfocused++; continue; }
+
+  const expected = src.filter((f) => index.has(f));
+  if (expected.length === 0) { stats.notIndexed++; continue; }
+  if (expected.some((f) => (seenFile.get(f) || 0) >= 5)) { stats.dupe++; continue; }
+
+  const query = cleanSubject(subject);
+  if (query.split(/\s+/).filter(Boolean).length < 4 || !isUsableSubject(query)) { stats.tooShort++; continue; }
+  if (seenQuery.has(query.toLowerCase())) { stats.dupe++; continue; }
+  if (!queryLeakage(query, expected).clean) { stats.leaked++; continue; }
+  if (verbatimHit(query, expected)) { stats.verbatim++; continue; }
+
+  seenQuery.add(query.toLowerCase());
+  for (const f of expected) seenFile.set(f, (seenFile.get(f) || 0) + 1);
+  tasks.push({ id: `m${String(tasks.length + 1).padStart(3, '0')}`, split: 'hard', source: 'git', sha: sha.slice(0, 8), query, expected_files: expected, repo: '.' });
+}
+
+writeFileSync(join(ROOT, OUT), tasks.map((t) => JSON.stringify(t)).join('\n') + '\n');
+console.log(`\nmined ${tasks.length} tasks from ${stats.scanned} commits -> ${OUT}`);
+console.log(`  dropped: unfocused ${stats.unfocused} | not-indexed ${stats.notIndexed} | leaked ${stats.leaked} | verbatim ${stats.verbatim} | dupe ${stats.dupe} | too-short ${stats.tooShort}`);

--- a/scripts/run-retrieval-gate.mjs
+++ b/scripts/run-retrieval-gate.mjs
@@ -1,0 +1,144 @@
+#!/usr/bin/env node
+/**
+ * Retrieval quality benchmark + regression gate.
+ *
+ *   node scripts/run-retrieval-gate.mjs             # report only
+ *   node scripts/run-retrieval-gate.mjs --gate      # exit 1 below the floor
+ *   node scripts/run-retrieval-gate.mjs --gate --no-regress
+ *   node scripts/run-retrieval-gate.mjs --save      # record a new baseline
+ *   node scripts/run-retrieval-gate.mjs --min 0.55  # override the floor
+ *
+ * KNOWN BIAS: tasks h031+ were authored after module-doc prose was indexed,
+ * so their phrasing shares the header's CONCEPTS even where the verbatim-ngram
+ * check passes. They score ~20pp above the tasks written before that (81.7% vs
+ * 61.1%). Treat the absolute number as optimistic relative to a real user's
+ * queries; the gate's job is detecting REGRESSION, which is unaffected.
+ *
+ * The gate is scored on `retrieval-hard.jsonl` — the leak-free split. The easy
+ * corpus is reported for context but NEVER gated: 11 of its 20 queries contain
+ * the answer's own filename, so it measures index coverage far more than it
+ * measures ranking, and it moves ~3x further than reality for any given change.
+ *
+ * Reproducibility: run with `learned: false` so a developer's local
+ * .context/weights.json cannot change the numbers CI sees. The retrieval index
+ * (.context/sig-index.json) is gitignored, so a fresh checkout is regenerated
+ * before scoring.
+ */
+
+import { readFileSync, writeFileSync, existsSync } from 'fs';
+import { join, dirname } from 'path';
+import { fileURLToPath } from 'url';
+import { execFileSync, } from 'child_process';
+import { createRequire } from 'module';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const ROOT = join(__dirname, '..');
+const require = createRequire(import.meta.url);
+
+const argv = process.argv.slice(2);
+const has = (f) => argv.includes(f);
+const val = (f, d) => { const i = argv.indexOf(f); return i !== -1 && argv[i + 1] ? argv[i + 1] : d; };
+
+const GATE = has('--gate');
+const NO_REGRESS = has('--no-regress');
+const SAVE = has('--save');
+const MIN = parseFloat(val('--min', '0.70'));
+// The mined corpus is smaller and genuinely harder — no author bias propping it up.
+// Floor set below the whole sensitivity band (53.3%-73.1% across defensible
+// miner parameters) so the gate catches genuine regression rather than firing
+// on corpus-parameter noise.
+const MIN_MINED = parseFloat(val('--min-mined', '0.50'));
+const BASELINE = join(ROOT, 'benchmarks', 'retrieval-baseline.json');
+const EPS = 1e-9;
+
+// The retrieval index is gitignored — regenerate on a cold checkout.
+if (!existsSync(join(ROOT, '.context', 'sig-index.json'))) {
+  console.log('[retrieval-gate] no retrieval index found — running generate first');
+  execFileSync('node', [join(ROOT, 'gen-context.js')], { cwd: ROOT, stdio: 'ignore' });
+}
+
+const { run } = require(join(ROOT, 'src/eval/runner'));
+const { queryLeakage } = require(join(ROOT, 'src/eval/corpus'));
+
+function score(file) {
+  const m = run(join('benchmarks/tasks', file), ROOT, { topK: 5, learned: false }).metrics;
+  return { hitAt5: m.hitAt5, mrr: m.mrr, precisionAt5: m.precisionAt5, tasks: m.tasks };
+}
+
+/** The hard split is worthless if it ever starts leaking — verify every run. */
+function assertLeakFree(file) {
+  const tasks = readFileSync(join(ROOT, 'benchmarks/tasks', file), 'utf8')
+    .split('\n').filter(Boolean).map((l) => JSON.parse(l));
+  const leaking = tasks.filter((t) => !queryLeakage(t.query, t.expected_files).clean);
+  return { total: tasks.length, leaking: leaking.map((t) => t.id) };
+}
+
+const hard = score('retrieval-hard.jsonl');
+const easy = score('retrieval.jsonl');
+const mined = score('retrieval-mined.jsonl');
+const leak = assertLeakFree('retrieval-hard.jsonl');
+const leakMined = assertLeakFree('retrieval-mined.jsonl');
+
+const pct = (n) => (n * 100).toFixed(1) + '%';
+console.log('\n[sigmap] retrieval quality\n');
+console.log('  corpus            tasks   hit@5     MRR     P@5');
+console.log('  ' + '-'.repeat(48));
+console.log(`  hard (gated)      ${String(hard.tasks).padStart(5)}   ${pct(hard.hitAt5).padStart(6)}   ${hard.mrr.toFixed(3)}   ${pct(hard.precisionAt5).padStart(6)}`);
+console.log(`  mined (gated)     ${String(mined.tasks).padStart(5)}   ${pct(mined.hitAt5).padStart(6)}   ${mined.mrr.toFixed(3)}   ${pct(mined.precisionAt5).padStart(6)}`);
+console.log(`  easy (reference)  ${String(easy.tasks).padStart(5)}   ${pct(easy.hitAt5).padStart(6)}   ${easy.mrr.toFixed(3)}   ${pct(easy.precisionAt5).padStart(6)}`);
+console.log('\n  mined = commit subjects + the files that commit touched. Nobody tuning');
+console.log('  the ranker wrote them, so it is the only unbiased number here.');
+console.log('  It is also SMALL: 1 task = ' + (100 / mined.tasks).toFixed(1) + 'pp, and the defensible miner');
+console.log('  parameter range spans 53-73%. Read it as a band, not a point.');
+
+const prior = existsSync(BASELINE) ? JSON.parse(readFileSync(BASELINE, 'utf8')) : null;
+if (prior && prior.hard) {
+  const dm2 = prior.mined ? mined.hitAt5 - prior.mined.hitAt5 : 0;
+  const d = hard.hitAt5 - prior.hard.hitAt5;
+  const dm = hard.mrr - prior.hard.mrr;
+  console.log(`\n  vs baseline       hard ${d >= 0 ? '+' : ''}${(d * 100).toFixed(1)}pp   mined ${dm2 >= 0 ? '+' : ''}${(dm2 * 100).toFixed(1)}pp   MRR ${dm >= 0 ? '+' : ''}${dm.toFixed(3)}`);
+}
+
+if (SAVE) {
+  writeFileSync(BASELINE, JSON.stringify({ hard, mined, easy, recordedBy: 'run-retrieval-gate.mjs' }, null, 2) + '\n');
+  console.log(`\n[retrieval-gate] baseline saved → ${BASELINE.replace(ROOT + '/', '')}`);
+}
+
+const reasons = [];
+if (leakMined.leaking.length > 0) {
+  reasons.push(`mined split leaks basename tokens in ${leakMined.leaking.length} task(s)`);
+}
+if (mined.hitAt5 < MIN_MINED - EPS) {
+  reasons.push(`mined hit@5 ${pct(mined.hitAt5)} below floor ${pct(MIN_MINED)}`);
+}
+if (NO_REGRESS && prior && prior.mined && mined.hitAt5 < prior.mined.hitAt5 - EPS) {
+  reasons.push(`mined hit@5 regressed ${pct(prior.mined.hitAt5)} -> ${pct(mined.hitAt5)}`);
+}
+if (leak.leaking.length > 0) {
+  reasons.push(`hard split leaks basename tokens in ${leak.leaking.length} task(s): ${leak.leaking.join(', ')}`);
+}
+if (hard.hitAt5 < MIN - EPS) {
+  reasons.push(`hard hit@5 ${pct(hard.hitAt5)} below floor ${pct(MIN)}`);
+}
+if (NO_REGRESS && prior && prior.hard && hard.hitAt5 < prior.hard.hitAt5 - EPS) {
+  reasons.push(`hard hit@5 regressed ${pct(prior.hard.hitAt5)} → ${pct(hard.hitAt5)}`);
+}
+
+// One task is worth 100/N points. Compute headroom in TASKS, not in
+// percentage points — float division of a k/N ratio rounds the answer off by one.
+const perTask = 100 / hard.tasks;
+const hits = Math.round(hard.hitAt5 * hard.tasks);
+const minHits = Math.ceil(MIN * hard.tasks - EPS);
+console.log(`\n  floor ${pct(MIN)}  ·  ${hits}/${hard.tasks} tasks pass  ·  1 task = ${perTask.toFixed(1)}pp  ·  ${Math.max(0, hits - minHits)} task(s) of headroom`);
+
+if (!GATE) {
+  console.log('\n[retrieval-gate] report only (pass --gate to enforce)\n');
+  process.exit(0);
+}
+if (reasons.length > 0) {
+  console.error('\n[retrieval-gate] FAIL');
+  for (const r of reasons) console.error('  ✗ ' + r);
+  console.error('');
+  process.exit(1);
+}
+console.log('\n[retrieval-gate] PASS\n');

--- a/src/eval/runner.js
+++ b/src/eval/runner.js
@@ -38,47 +38,12 @@ const { bm25rank } = require('../retrieval/bm25');
  * @returns {Map<string, string[]>}
  */
 function buildSigIndex(cwd) {
-  const contextPath = path.join(cwd, '.github', 'copilot-instructions.md');
-  const index = new Map();
-
-  if (!fs.existsSync(contextPath)) return index;
-
-  const content = fs.readFileSync(contextPath, 'utf8');
-  const lines = content.split('\n');
-
-  let currentFile = null;
-  let inBlock = false;
-  let sigs = [];
-
-  for (const line of lines) {
-    // Section header: ### path/to/file.js
-    const headerMatch = line.match(/^###\s+(\S+\.\w+)\s*$/);
-    if (headerMatch) {
-      if (currentFile !== null) {
-        index.set(currentFile, sigs);
-      }
-      currentFile = headerMatch[1];
-      sigs = [];
-      inBlock = false;
-      continue;
-    }
-
-    if (line.startsWith('```')) {
-      inBlock = !inBlock;
-      continue;
-    }
-
-    if (inBlock && currentFile && line.trim()) {
-      sigs.push(line.trim());
-    }
-  }
-
-  // Flush last file
-  if (currentFile !== null) {
-    index.set(currentFile, sigs);
-  }
-
-  return index;
+  // Delegate to the production index builder. This used to parse
+  // .github/copilot-instructions.md directly — a second parallel implementation
+  // that saw only the token-BUDGETED view, ignored the other adapters, the
+  // hot-cold/per-module strategy splits, and the complete retrieval index. The
+  // corpus therefore scored a smaller index than `sigmap ask` actually uses.
+  return require('../retrieval/ranker').buildSigIndex(cwd);
 }
 
 // ---------------------------------------------------------------------------
@@ -96,12 +61,13 @@ const { tokenize } = require('../retrieval/bm25');
  * @param {number} topK
  * @returns {{ file: string, score: number, sigs: string[] }[]}
  */
-function rank(query, index, topK = 10) {
-  const candidates = [];
-  for (const [file, sigs] of index.entries()) {
-    candidates.push({ file, sigs });
-  }
-  return bm25rank(query, candidates).slice(0, topK);
+function rank(query, index, topK = 10, opts = {}) {
+  // Measure the ranker users actually hit. This used to call bm25rank directly,
+  // which meant the corpus scored a parallel implementation with no penalties,
+  // graph boost, recency or learned weights — so no ranking regression in
+  // src/retrieval/ranker.js could ever show up in the benchmark numbers.
+  const { rank: prodRank } = require('../retrieval/ranker');
+  return prodRank(query, index, Object.assign({ topK }, opts)).slice(0, topK);
 }
 
 // ---------------------------------------------------------------------------
@@ -188,11 +154,14 @@ function run(tasksFile, cwd, opts = {}) {
 
   // Build index once (re-used across all tasks in the same repo)
   const index = buildSigIndex(cwd);
+  // Import graph built once too — the hop-1/hop-2 boost is part of what ships.
+  let graph = null;
+  try { graph = require('../graph/builder').buildFromCwd(cwd); } catch (_) {}
 
   const taskResults = [];
   for (const task of tasks) {
-    const ranked = rank(task.query, index, topK).map((r) => r.file);
-    const topResult = rank(task.query, index, topK);
+    const topResult = rank(task.query, index, topK, { cwd, graph, learned: opts.learned });
+    const ranked = topResult.map((r) => r.file);
     const tokens = topResult.reduce((sum, r) => sum + estimateTokens(r.sigs), 0);
 
     const { hitAtK, reciprocalRank, precisionAtK } = require('./scorer');

--- a/src/graph/builder.js
+++ b/src/graph/builder.js
@@ -12,10 +12,11 @@
 const fs   = require('fs');
 const path = require('path');
 
-// Normalize paths for cross-platform consistency (Windows uses backslashes, Unix uses forward slashes)
-// Use lowercase to enable case-insensitive lookups on case-sensitive Windows filesystems
+// Cross-platform node key. Delegates to the ONE shared definition so this graph
+// and the call-graph cannot drift apart again (see src/graph/path-key.js).
+const { graphKey } = require('./path-key');
 function normalizePath(p) {
-  return path.normalize(p).toLowerCase();
+  return graphKey(p);
 }
 
 // ---------------------------------------------------------------------------

--- a/src/graph/call-graph.js
+++ b/src/graph/call-graph.js
@@ -38,7 +38,8 @@ const NON_CALL = new Set([
   'synchronized',
 ]);
 
-function normalizePath(p) { return path.normalize(p).toLowerCase(); }
+const { graphKey } = require('./path-key');
+function normalizePath(p) { return graphKey(p); }
 function toRel(cwd, f) { return path.relative(cwd, f).replace(/\\/g, '/'); }
 function symId(cwd, absFile, name) { return `${toRel(cwd, absFile)}#${name}`; }
 
@@ -470,8 +471,11 @@ function buildCallFileGraph(cwd, opts = {}) {
     for (const calleeId of calleeIds) {
       const calleeDef = graph.defs.get(calleeId);
       if (!calleeDef || calleeDef.file === callerDef.file) continue;
-      const a = path.resolve(cwd, callerDef.file);
-      const b = path.resolve(cwd, calleeDef.file);
+      // Keyed through graphKey so the file-level call graph shares ONE key space
+      // with the import graph. Previously this kept case while builder.js
+      // lowercased, so a lookup correct for one silently missed on the other.
+      const a = graphKey(path.resolve(cwd, callerDef.file));
+      const b = graphKey(path.resolve(cwd, calleeDef.file));
       add(a, b);
       add(b, a);
     }

--- a/src/graph/path-key.js
+++ b/src/graph/path-key.js
@@ -1,0 +1,26 @@
+'use strict';
+
+/**
+ * The single definition of a graph node key.
+ *
+ * src/graph/builder.js and src/graph/call-graph.js each used to normalise paths
+ * their own way — builder lowercased, call-graph did not — so a lookup written
+ * for one silently missed on the other. That divergence disabled the import
+ * boost on every repo whose path contains an uppercase letter, and later caused
+ * a "fix" for one graph to break the other. Both now key through this function,
+ * so there is one convention rather than two conventions and a convention.
+ *
+ * Lowercasing keeps lookups stable across case-insensitive filesystems (macOS,
+ * Windows), where the same file legitimately arrives spelled two ways.
+ *
+ * Zero-dependency, pure, bundle-safe.
+ */
+
+const path = require('path');
+
+/** Canonical key for a filesystem path used as a graph node. */
+function graphKey(p) {
+  return path.normalize(String(p)).toLowerCase();
+}
+
+module.exports = { graphKey };

--- a/src/retrieval/bm25.js
+++ b/src/retrieval/bm25.js
@@ -108,6 +108,33 @@ const EXPANSION_GROUPS = [
 // the literal query token always outranks a synonym-only match.
 const EXPANSION_WEIGHT = 0.15;
 
+// Module-doc prose is indexed as a `# module: ...` pseudo-signature (index-only,
+// see src/retrieval/module-doc.js). Per token it is a weaker relevance signal
+// than a real signature — descriptive rather than definitional — so it is scored
+// as its own BM25F field rather than pooled with the code terms.
+const MODULE_DOC_RE = /^#\s*(module|docs):/;
+
+// Line anchors are metadata, not content, and this ranker is documented as
+// anchor-invariant. The previous strip was end-anchored, so it only fired when
+// the anchor was the last thing on the line — but extractors append a doc hint
+// AFTER it ("... :27-59  # Compute a normalized centrality score"). 27% of
+// signatures therefore leaked their line numbers into the term space as tokens
+// like "27" and "59": 840 junk terms, inflating document length for exactly the
+// well-documented files, which BM25 then penalised via length normalisation.
+const ANCHOR_RE = /\s*:\d+(?:-\d+)?(?=\s|$)/g;
+
+function stripAnchor(line) {
+  return String(line).replace(ANCHOR_RE, '');
+}
+// Tuned on the 30-task leak-free corpus. The 0.5-0.8 band is flat
+// (hit@5 63.3-66.7%, easy MRR steady at 0.825); adjacent values swing by up to
+// 6.7pp, which at 30 tasks is literally two tasks — noise, not signal. 0.6 is
+// chosen from the middle of that band rather than at its peak, because a
+// per-token weight below 1 is the principled position (prose is descriptive,
+// a signature is definitional) and picking the argmax of a 30-task sweep is
+// how you overfit a benchmark.
+const DOC_WEIGHT = 0.6;
+
 // Build a stemmed lookup: stem(member) → Set of the group's other stemmed members.
 const EXPANSIONS = (() => {
   const map = new Map();
@@ -151,22 +178,45 @@ function expandQuery(qToks) {
  * @param {{ file: string, sigs: string[] }[]} candidates
  * @returns {Array<object & { score: number }>}
  */
-function bm25rank(query, candidates) {
+function bm25rank(query, candidates, opts) {
   if (!Array.isArray(candidates) || candidates.length === 0) return [];
 
   const k1 = 1.5;
   const b = 0.75;
+
+  const docWeight = (opts && typeof opts.docWeight === 'number') ? opts.docWeight : DOC_WEIGHT;
 
   const docs = candidates.map((c) => {
     const pathToks = tokenize(c.file || '');
     // Ranking is anchor-invariant: `:start-end` line anchors are metadata,
     // not content — strip them before tokenizing so adding anchors to an
     // extractor never shifts BM25 length normalization or token counts.
-    const toks = tokenize((c.sigs || []).map((s) => String(s).replace(/\s*:\d+(?:-\d+)?\s*$/, '')).join(' '));
-    for (let i = 0; i < PATH_BOOST; i++) toks.push(...pathToks);
+    // BM25F-style fields. Module-doc prose and code signatures are different
+    // kinds of evidence and must not share one term-frequency pool: prose is
+    // ~30% of all indexed tokens, and a short file with a long header (few
+    // signatures, lots of description) otherwise wins unrelated queries purely
+    // through length normalisation.
+    const docLines = [];
+    const codeLines = [];
+    for (const line of (c.sigs || [])) (MODULE_DOC_RE.test(line) ? docLines : codeLines).push(line);
+    // TRIED AND REJECTED: splitting the declared symbol NAME into its own
+    // weighted BM25F field, on the IR prior that a name is a "title" and params
+    // are "body". Swept 1.0-4.0. hit@5 on the mined corpus rose 60.9% -> 65.2%,
+    // which is a single task crossing the rank-5 line — over 113 combined tasks
+    // hit@1 fell 52.2% -> 51.3%, hit@3 fell 66.4% -> 65.5%, hit@10 was identical
+    // and MRR dropped. It moves correct answers DOWN and happens to nudge one
+    // past a cutoff. A hit@5-only view would have shipped this.
+    const codeToks = tokenize(codeLines.map((x) => stripAnchor(x)).join(' '));
+    const docToks = tokenize(docLines.join(' '));
     const tf = new Map();
-    for (const t of toks) tf.set(t, (tf.get(t) || 0) + 1);
-    return { cand: c, tf, len: toks.length };
+    const addField = (toks, weight) => { for (const t of toks) tf.set(t, (tf.get(t) || 0) + weight); };
+    addField(codeToks, 1);
+    addField(pathToks, PATH_BOOST);
+    addField(docToks, docWeight);
+    // Length accumulates with the SAME weights, or a field's influence leaks
+    // back in through the normalisation term.
+    const len = codeToks.length + (PATH_BOOST * pathToks.length) + (docWeight * docToks.length);
+    return { cand: c, tf, len };
   });
 
   const N = docs.length || 1;
@@ -195,4 +245,4 @@ function bm25rank(query, candidates) {
     .sort((a, c) => c.score - a.score || String(a.file).localeCompare(String(c.file)));
 }
 
-module.exports = { tokenize, stem, bm25rank, PATH_BOOST, STOP, expandQuery, EXPANSIONS, EXPANSION_WEIGHT };
+module.exports = { tokenize, stem, bm25rank, PATH_BOOST, STOP, expandQuery, EXPANSIONS, EXPANSION_WEIGHT, DOC_WEIGHT, MODULE_DOC_RE, stripAnchor };

--- a/src/retrieval/module-doc.js
+++ b/src/retrieval/module-doc.js
@@ -1,0 +1,120 @@
+'use strict';
+
+/**
+ * Module-level documentation extractor (retrieval only).
+ *
+ * Signatures describe a file's SHAPE — names, params, return types. A module's
+ * leading comment describes its PURPOSE, in prose, using the words a person
+ * would actually search with. That prose is the bridge between a behavioural
+ * query ("what fraction of the repo made it into the output") and the code
+ * that implements it (`coverageScore(cwd, fileEntries, config)`), which shares
+ * not one token with the query.
+ *
+ * This text is added to the RETRIEVAL INDEX ONLY — never to the generated
+ * context file. The prompt artifact is token-budgeted and prose is expensive
+ * there; the index is not injected into any prompt, so it can afford the words
+ * that make a file findable.
+ *
+ * Zero-dependency, pure, bundle-safe.
+ */
+
+// Enough to characterise a module without letting one verbose header dominate
+// BM25 length normalisation for the whole corpus.
+const MAX_CHARS = 400;
+const MAX_SCAN_LINES = 60;
+
+// Legal boilerplate is high-frequency noise: it appears in many files, shares no
+// vocabulary with real queries, and would flatten idf across the corpus.
+const BOILERPLATE = /\b(copyright|licensed under|SPDX-License|all rights reserved|permission is hereby granted)\b/i;
+
+const BLOCK_LANGS = new Set(['js', 'jsx', 'ts', 'tsx', 'java', 'go', 'rs', 'kt', 'swift', 'scala', 'cs', 'php', 'dart', 'c', 'cpp', 'h']);
+const HASH_LANGS = new Set(['py', 'rb', 'r', 'sh', 'yml', 'yaml', 'toml']);
+
+function _extOf(filePath) {
+  const m = String(filePath).match(/\.([A-Za-z0-9]+)$/);
+  return m ? m[1].toLowerCase() : '';
+}
+
+/** Strip comment furniture, JSDoc tags, and markup from one raw comment line. */
+function _cleanLine(line) {
+  return String(line)
+    .replace(/^\s*[/*#-]+\s?/, '')      // leading // /* * # ---
+    .replace(/\*+\/\s*$/, '')            // trailing */
+    .replace(/^\s*@\w+.*$/, '')          // @param / @returns tag lines
+    .replace(/[*_`]/g, '')               // markdown emphasis / code ticks
+    .trim();
+}
+
+/**
+ * Extract a module's leading documentation prose.
+ *
+ * @param {string} src       file contents
+ * @param {string} filePath  used only to pick a comment syntax
+ * @returns {string} collapsed prose, capped, or '' when there is none
+ */
+function extractModuleDoc(src, filePath) {
+  if (!src || typeof src !== 'string') return '';
+  const ext = _extOf(filePath);
+  const lines = src.split('\n', MAX_SCAN_LINES);
+
+  const collected = [];
+  let inBlock = false;
+  let started = false;
+
+  for (const raw of lines) {
+    const line = raw.trim();
+    if (!started) {
+      // Skip preamble that precedes the real header comment.
+      if (!line) continue;
+      if (line.startsWith('#!')) continue;                       // shebang
+      if (/^['"]use strict['"];?$/.test(line)) continue;
+      if (/^(package|import|from|using|#include)\b/.test(line)) continue;
+    }
+
+    if (BLOCK_LANGS.has(ext) || ext === '') {
+      if (!inBlock && line.startsWith('/*')) { inBlock = true; started = true; }
+      if (inBlock) {
+        const cleaned = _cleanLine(line);
+        if (cleaned) collected.push(cleaned);
+        if (line.includes('*/')) break;
+        continue;
+      }
+      if (line.startsWith('//')) {                                // run of // lines
+        started = true;
+        const cleaned = _cleanLine(line);
+        if (cleaned) collected.push(cleaned);
+        continue;
+      }
+      if (started || collected.length) break;
+      break;                                                      // first real code — no header
+    }
+
+    if (HASH_LANGS.has(ext)) {
+      if (/^("""|''')/.test(line)) {                              // python docstring
+        started = true; inBlock = !inBlock;
+        const cleaned = _cleanLine(line.replace(/^("""|''')/, '').replace(/("""|''')$/, ''));
+        if (cleaned) collected.push(cleaned);
+        if (!inBlock) break;
+        continue;
+      }
+      if (inBlock) { const c = _cleanLine(line); if (c) collected.push(c); continue; }
+      if (line.startsWith('#')) { started = true; const c = _cleanLine(line); if (c) collected.push(c); continue; }
+      if (collected.length) break;
+      break;
+    }
+    break;
+  }
+
+  const text = collected.join(' ').replace(/\s+/g, ' ').trim();
+  if (!text || BOILERPLATE.test(text)) return '';
+  if (text.length <= MAX_CHARS) return text;
+  return text.slice(0, MAX_CHARS).replace(/\s+\S*$/, '');        // never cut mid-word
+}
+
+/** Render as an index-only pseudo-signature, or '' when there is no doc. */
+function moduleDocSig(src, filePath) {
+  const doc = extractModuleDoc(src, filePath);
+  return doc ? `# module: ${doc}` : '';
+}
+
+module.exports = { extractModuleDoc, moduleDocSig, MAX_CHARS };

--- a/src/retrieval/ranker.js
+++ b/src/retrieval/ranker.js
@@ -19,7 +19,7 @@
 
 const { loadWeights } = require('../learning/weights');
 const { tokenize, STOP_WORDS } = require('./tokenizer');
-const { bm25rank } = require('./bm25');
+const { bm25rank, MODULE_DOC_RE } = require('./bm25');
 
 // ---------------------------------------------------------------------------
 // Default weights
@@ -43,17 +43,28 @@ const GRAPH_BOOST_AMOUNTS = {
 // Max additive prior for import-graph centrality (opt-in retrieval.centralityBlend)
 const CENTRALITY_BLEND_WEIGHT = 0.3;
 
-// Intent-specific weight adjustments
-const INTENT_WEIGHTS = {
-  search:     DEFAULT_WEIGHTS,
-  debug:      { ...DEFAULT_WEIGHTS, exactToken: 1.2, pathMatch: 0.6 },
-  explain:    { ...DEFAULT_WEIGHTS, symbolMatch: 0.8, pathMatch: 0.9 },
-  refactor:   { ...DEFAULT_WEIGHTS, symbolMatch: 0.9, exactToken: 0.8 },
-  review:     { ...DEFAULT_WEIGHTS, pathMatch: 1.0, exactToken: 0.9 },
-  test:       { ...DEFAULT_WEIGHTS, exactToken: 0.7, symbolMatch: 0.4 },
-  integrate:  { ...DEFAULT_WEIGHTS, graphBoost: 0.7, pathMatch: 1.1 },
-  navigate:   { ...DEFAULT_WEIGHTS, pathMatch: 1.2, exactToken: 0.9 },
-};
+// Per-intent weight profiles were removed in favour of a single weight set.
+// They were provably inert: scoreFile's score was discarded by rank(), so the
+// profiles only ever reached the explain table. Once the signal WAS wired into
+// the score (see SIGNAL_BLEND below), a sweep over the leak-free hard corpus
+// showed intent-specific profiles produced byte-identical metrics to the flat
+// DEFAULT_WEIGHTS at every blend value — so they earn nothing and are gone.
+// `detectIntent` is retained: it is still reported to the user and is the right
+// hook for shaping OUTPUT depth later.
+
+// How much the weighted keyword/symbol/path signal modulates the BM25 base.
+// Multiplicative and bounded, so it can only reorder files that already match —
+// it can never lift a zero-BM25 file into the results. Tuned on the leak-free
+// corpus: 0.5 gave hit@5 50.0% -> 56.7% and MRR 0.419 -> 0.447; higher values
+// held hit@5 but degraded MRR.
+const SIGNAL_BLEND = 0.5;
+
+// TRIED AND REJECTED: a same-line co-occurrence bonus, on the theory that a file
+// declaring `parseAuthToken` should outrank one mentioning `parseAuth` and
+// `token` on separate lines. Swept 0.15-1.0: hit@5 did not move on either the
+// 90-task authored corpus or the 32-task mined one, and MRR degraded
+// monotonically as the weight rose. Signatures are short and dense enough that
+// BM25's bag already captures this. Not reinstated without new evidence.
 
 // Penalty multipliers for negative signals
 const PENALTY_SIGNALS = {
@@ -63,12 +74,36 @@ const PENALTY_SIGNALS = {
   nodeModules:   0.0,    // node_modules (zero score)
 };
 
-function _computePenalty(filePath) {
+// Query terms that mean the penalised category IS the target. Read from the
+// query tokens directly, NOT via detectIntent: that classifier is first-match-
+// wins over its pattern object, and `debug` precedes `test`, so "fix the failing
+// test" classifies as debug and never reaches the test branch.
+const WANTS_TESTS = new Set(['test', 'tests', 'spec', 'specs', 'unit', 'integration', 'e2e', 'assertion', 'assert', 'mock', 'fixture', 'coverage', 'testing']);
+const WANTS_DOCS = new Set(['doc', 'docs', 'documentation', 'readme', 'changelog', 'guide', 'tutorial']);
+
+/** Which penalised categories the query is explicitly asking for. */
+function _queryWants(queryTokens) {
+  const wants = { tests: false, docs: false };
+  for (const t of queryTokens || []) {
+    if (WANTS_TESTS.has(t)) wants.tests = true;
+    if (WANTS_DOCS.has(t)) wants.docs = true;
+  }
+  return wants;
+}
+
+function _computePenalty(filePath, wants) {
   const pathLower = filePath.toLowerCase();
   if (pathLower.includes('node_modules')) return PENALTY_SIGNALS.nodeModules;
-  if (/(^|\/)(test|tests|spec|__tests__|e2e)($|\/)/.test(pathLower)) return PENALTY_SIGNALS.testFile;
+  // A penalty must never fire on the very thing the user asked for. Before
+  // this, "write tests for the ranker" multiplied every test file by 0.4 —
+  // the query and the penalty were pulling in opposite directions.
+  if (/(^|\/)(test|tests|spec|__tests__|e2e)($|\/)/.test(pathLower) || /\.(test|spec)\./.test(pathLower)) {
+    return (wants && wants.tests) ? 1.0 : PENALTY_SIGNALS.testFile;
+  }
   if (/(^|\/)(dist|build|\.next|\.nuxt|out|\.venv|venv)($|\/)/.test(pathLower)) return PENALTY_SIGNALS.generatedCode;
-  if (/(^|\/)(docs|doc|readme|changelog)($|\/)/.test(pathLower)) return PENALTY_SIGNALS.docsFile;
+  if (/(^|\/)(docs|doc|readme|changelog)($|\/)/.test(pathLower)) {
+    return (wants && wants.docs) ? 1.0 : PENALTY_SIGNALS.docsFile;
+  }
   return 1.0;
 }
 
@@ -87,6 +122,26 @@ function _computeHubs(graph) {
 }
 
 // Common utility paths that should be treated as hubs regardless of fanout
+// The graph builders disagree on key case: src/graph/builder.js lowercases every
+// node (normalizePath), while src/graph/call-graph.js keys by a case-preserving
+// path.resolve. Assuming either one breaks the other, so every graph lookup in
+// this file probes both forms — the same thing the centrality blend already does.
+function _graphKeys(p) {
+  const norm = require('path').normalize(p);
+  const lower = norm.toLowerCase();
+  return lower === norm ? [norm] : [norm, lower];
+}
+function _graphGet(map, absPath) {
+  for (const k of _graphKeys(absPath)) {
+    const hit = map.get(k);
+    if (hit !== undefined) return hit;
+  }
+  return undefined;
+}
+function _registerKeys(map, absPath, value) {
+  for (const k of _graphKeys(absPath)) if (!map.has(k)) map.set(k, value);
+}
+
 function _isHub(filePath) {
   return /\/(utils|helpers|shared|common|constants|types|interfaces|index|zzz|globals)\.(ts|tsx|js|jsx|r|R)$/.test(filePath)
       || filePath.endsWith('/index.ts') || filePath.endsWith('/index.js')
@@ -102,14 +157,18 @@ function _isHub(filePath) {
  * @param {object}   weights
  * @returns {{ score: number, signals: { exactToken: number, symbolMatch: number, prefixMatch: number, pathMatch: number, penalty: number } }}
  */
-function scoreFile(filePath, sigs, queryTokens, weights) {
+function scoreFile(filePath, sigs, queryTokens, weights, wants) {
   if (!sigs || sigs.length === 0) return { score: 0, signals: { exactToken: 0, symbolMatch: 0, prefixMatch: 0, pathMatch: 0, penalty: 1.0 } };
 
   const w = weights || DEFAULT_WEIGHTS;
-  const signals = { exactToken: 0, symbolMatch: 0, prefixMatch: 0, pathMatch: 0, penalty: _computePenalty(filePath) };
+  const signals = { exactToken: 0, symbolMatch: 0, prefixMatch: 0, pathMatch: 0, penalty: _computePenalty(filePath, wants) };
 
-  // Build token set from all signatures
-  const sigText = sigs.join(' ');
+  // Module-doc prose is excluded here on purpose. This signal measures overlap
+  // with DECLARED IDENTIFIERS; prose relevance is BM25's job, where it is scored
+  // as its own weighted field. Letting descriptive text inflate the identifier
+  // signal double-counts it and measurably degraded MRR.
+  const codeSigs = sigs.filter((line) => !MODULE_DOC_RE.test(line));
+  const sigText = codeSigs.join(' ');
   const sigTokenSet = new Set(tokenize(sigText));
 
   // Build token set from the file path
@@ -127,7 +186,7 @@ function scoreFile(filePath, sigs, queryTokens, weights) {
       signals.exactToken += bonus;
 
       // Bonus: appears directly in a function/class/method name line
-      const nameLineMatch = sigs.some((sig) => {
+      const nameLineMatch = codeSigs.some((sig) => {
         const nt = tokenize(sig.replace(/[^a-zA-Z0-9_\s]/g, ' '));
         return nt.includes(qt);
       });
@@ -189,13 +248,18 @@ function rank(query, sigIndex, opts) {
   const graph = (opts && opts.graph && opts.graph.forward instanceof Map) ? opts.graph : null;
   const cwd = (opts && opts.cwd) || null;
 
-  // Detect query intent and get appropriate weights
+  // Intent is reported to the user and shapes output depth; it no longer
+  // selects scoring weights (see SIGNAL_BLEND).
   const intent = detectIntent(query);
-  const intentWeights = INTENT_WEIGHTS[intent] || DEFAULT_WEIGHTS;
-  const weights = (opts && opts.weights) ? Object.assign({}, intentWeights, opts.weights) : intentWeights;
-  const learnedWeights = opts && opts.cwd ? loadWeights(opts.cwd) : null;
+  const weights = (opts && opts.weights) ? Object.assign({}, DEFAULT_WEIGHTS, opts.weights) : DEFAULT_WEIGHTS;
+  // Learned per-file multipliers are a LOCAL, evolving signal (.context/weights.json).
+  // Benchmarks and CI gates must opt out via { learned: false }, or a developer's
+  // local learned state silently changes the score and CI stops being reproducible.
+  const useLearned = !(opts && opts.learned === false);
+  const learnedWeights = opts && opts.cwd && useLearned ? loadWeights(opts.cwd) : null;
 
   const queryTokens = tokenize(query);
+  const queryWants = _queryWants(queryTokens);
   if (queryTokens.length === 0) {
     // Empty query: return top-K by file count (most signatures = most useful)
     const all = [];
@@ -212,18 +276,32 @@ function rank(query, sigIndex, opts) {
   // are matched. The existing negative-signal penalty and recency/graph/learned
   // boosts are layered on top; the per-token signals stay for the explain table.
   const bm25Scores = new Map();
-  for (const c of bm25rank(query, [...sigIndex.entries()].map(([file, sigs]) => ({ file, sigs })))) {
+  for (const c of bm25rank(query, [...sigIndex.entries()].map(([file, sigs]) => ({ file, sigs })), opts)) {
     bm25Scores.set(c.file, c.score);
   }
 
-  const scored = [];
+  // Two passes: scoreFile's weighted signal needs the max across the corpus to
+  // normalise against, so collect first, then combine.
+  const prescored = [];
+  let maxSignal = 0;
   for (const [file, sigs] of sigIndex.entries()) {
-    const result = scoreFile(file, sigs, queryTokens, weights);
+    const result = scoreFile(file, sigs, queryTokens, weights, queryWants);
+    if (result.score > maxSignal) maxSignal = result.score;
+    prescored.push({ file, sigs, result });
+  }
+
+  const scored = [];
+  for (const { file, sigs, result } of prescored) {
     const penalty = result.signals.penalty;
     const base = bm25Scores.get(file) || 0;
-    let score = base * penalty;
+    // Blend the weighted keyword/symbol/path signal into the BM25 base. This
+    // was previously computed and thrown away — `result.score` was never read,
+    // which silently made DEFAULT_WEIGHTS and every intent profile dead config.
+    const signalNorm = maxSignal > 0 ? result.score / maxSignal : 0;
+    let score = base * penalty * (1 + SIGNAL_BLEND * signalNorm);
     const signals = result.signals;
     signals.bm25 = base;
+    signals.signalBlend = signalNorm;
 
     // Recency boost
     if (recencySet && recencySet.has(file) && score > 0) {
@@ -253,44 +331,46 @@ function rank(query, sigIndex, opts) {
   // Hub suppression: files with high fanout (>20%) are not boosted
   if (graph && cwd) {
     const path = require('path');
-    // Build maps for relative ↔ absolute path conversion and index lookup
-    const relToIdx = new Map();
-    const absToRel = new Map();
+    // Every graph node is keyed by `path.normalize(p).toLowerCase()` (see
+    // normalizePath in src/graph/builder.js and src/graph/call-graph.js).
+    // Lookups MUST use the same key space: a bare path.resolve() preserves
+    // case, so on any repo whose absolute path contains an uppercase letter
+    // every .get() missed and this entire block was silently inert.
+    const keyToIdx = new Map();
     for (let i = 0; i < scored.length; i++) {
-      relToIdx.set(scored[i].file, i);
-      const abs = path.resolve(cwd, scored[i].file);
-      absToRel.set(abs, scored[i].file);
+      _registerKeys(keyToIdx, path.resolve(cwd, scored[i].file), i);
     }
 
     const hubs = _computeHubs(graph);
-    const hop1Files = new Set(); // track which files received hop1 boost
+    const hop1Files = new Set(); // normalised keys that received a hop1 boost
+    const hop1Seeds = [];        // original (un-normalised) paths, for hop-2 lookup
 
     // Hop 1: direct neighbors of scored files
     for (const entry of scored) {
       if (entry.score <= 0) continue;
-      const abs = path.resolve(cwd, entry.file);
-      const neighbors = graph.forward.get(abs) || [];
+      const neighbors = _graphGet(graph.forward, path.resolve(cwd, entry.file)) || [];
       for (const neighborAbs of neighbors) {
-        if (_isHub(neighborAbs) || hubs.has(neighborAbs)) continue;
-        const neighborRel = path.relative(cwd, neighborAbs).replace(/\\/g, '/');
-        const idx = relToIdx.get(neighborRel);
+        const nk = path.normalize(neighborAbs);
+        if (_isHub(nk) || hubs.has(nk) || hubs.has(nk.toLowerCase())) continue;
+        const idx = _graphGet(keyToIdx, nk);
         if (idx !== undefined) {
           scored[idx].score += GRAPH_BOOST_AMOUNTS.hop1;
           scored[idx].signals.graphBoost = (scored[idx].signals.graphBoost || 0) + GRAPH_BOOST_AMOUNTS.hop1;
-          hop1Files.add(neighborAbs);
+          hop1Files.add(nk);
+          hop1Seeds.push(neighborAbs);
         }
       }
     }
 
     // Hop 2: neighbors of hop1 files (only if they didn't get a direct score)
-    for (const hop1File of hop1Files) {
-      if (!absToRel.has(hop1File)) continue; // skip files not in index
-      const neighbors = graph.forward.get(hop1File) || [];
+    for (const hop1Key of hop1Seeds) {
+      if (_graphGet(keyToIdx, hop1Key) === undefined) continue; // skip files not in index
+      const neighbors = _graphGet(graph.forward, hop1Key) || [];
       for (const neighborAbs of neighbors) {
-        if (_isHub(neighborAbs) || hubs.has(neighborAbs)) continue;
-        if (hop1Files.has(neighborAbs)) continue; // skip already hop1-boosted
-        const neighborRel = path.relative(cwd, neighborAbs).replace(/\\/g, '/');
-        const idx = relToIdx.get(neighborRel);
+        const nk = path.normalize(neighborAbs);
+        if (_isHub(nk) || hubs.has(nk) || hubs.has(nk.toLowerCase())) continue;
+        if (hop1Files.has(nk)) continue; // skip already hop1-boosted
+        const idx = _graphGet(keyToIdx, nk);
         if (idx !== undefined && scored[idx].score > 0) {
           // Only boost files that have some baseline score (not noise)
           scored[idx].score += GRAPH_BOOST_AMOUNTS.hop2;
@@ -307,16 +387,17 @@ function rank(query, sigIndex, opts) {
   const callGraph = (opts && opts.callGraph && opts.callGraph.forward instanceof Map) ? opts.callGraph : null;
   if (callGraph && cwd) {
     const path = require('path');
-    const relToIdx = new Map();
-    for (let i = 0; i < scored.length; i++) relToIdx.set(scored[i].file, i);
+    // buildCallFileGraph keys by a CASE-PRESERVING path.resolve, unlike the
+    // import graph builder which lowercases — hence the dual-form probe.
+    const keyToIdx = new Map();
+    for (let i = 0; i < scored.length; i++) _registerKeys(keyToIdx, path.resolve(cwd, scored[i].file), i);
     const hubs = _computeHubs(callGraph);
     const seeds = scored.filter((e) => e.score > 0).map((e) => e.file);
     for (const file of seeds) {
-      const abs = path.resolve(cwd, file);
-      for (const neighborAbs of (callGraph.forward.get(abs) || [])) {
-        if (_isHub(neighborAbs) || hubs.has(neighborAbs)) continue;
-        const neighborRel = path.relative(cwd, neighborAbs).replace(/\\/g, '/');
-        const idx = relToIdx.get(neighborRel);
+      for (const neighborAbs of (_graphGet(callGraph.forward, path.resolve(cwd, file)) || [])) {
+        const nk = path.normalize(neighborAbs);
+        if (_isHub(nk) || hubs.has(nk) || hubs.has(nk.toLowerCase())) continue;
+        const idx = _graphGet(keyToIdx, nk);
         if (idx !== undefined && scored[idx].file !== file) {
           scored[idx].score += GRAPH_BOOST_AMOUNTS.callHop;
           scored[idx].signals.callGraphBoost = (scored[idx].signals.callGraphBoost || 0) + GRAPH_BOOST_AMOUNTS.callHop;
@@ -490,6 +571,18 @@ function _enrichSigIndexFromStrategy(cwd, index) {
     }
   } catch (_) {}
   _mergeSigIndex(index, _buildSigIndexFromCache(cwd));
+
+  // The complete retrieval index (written by generate before applyTokenBudget)
+  // takes precedence: it is the only source containing files the budget dropped,
+  // and full signatures for files the budget collapsed to line anchors. It is
+  // merged as the BASE rather than on top because _mergeSigIndex only replaces
+  // when the source has MORE signatures — a collapsed entry has the same count
+  // as its full form, so merging the other way would keep the anchors.
+  try {
+    const full = require('./sig-index-store').readFullIndex(cwd);
+    if (full.size > 0) return _mergeSigIndex(full, index);
+  } catch (_) { /* absent → budgeted view is still served */ }
+
   return index;
 }
 
@@ -615,22 +708,53 @@ function formatRankJSON(results, query) {
 // ---------------------------------------------------------------------------
 // Intent detection — 7 intents
 // ---------------------------------------------------------------------------
+// Nouns carry an optional plural: `\btest\b` does not match "tests", so
+// "write unit tests for the ranker" matched NO intent at all and fell through
+// to the 'search' default.
 const INTENT_PATTERNS = {
-  debug:    /\b(bug|fix|error|crash|exception|broken|failing|issue|problem|regression)\b/i,
+  debug:    /\b(bugs?|fix(es|ed)?|errors?|crash(es)?|exceptions?|broken|failing|failures?|issues?|problems?|regressions?)\b/i,
   explain:  /\b(explain|how does|what is|understand|overview|architecture|describe|walk me|teach)\b/i,
-  refactor: /\b(refactor|restructure|redesign|clean up|extract|move|rename|simplify|optimize)\b/i,
+  refactor: /\b(refactor|restructure|redesign|clean up|extract|move|rename|simplify|optimi[sz]e)\b/i,
   review:   /\b(review|check|audit|security|pr|pull request|assess|validate)\b/i,
-  test:     /\b(test|unit test|integration test|testing|spec|assert|mock)\b/i,
-  integrate:/\b(import|integrate|connect|wire|bind|require|export|depend|graph)\b|require[ds]\b/i,
+  test:     /\b(tests?|unit tests?|integration tests?|testing|specs?|assert(ion)?s?|mocks?|fixtures?)\b/i,
+  integrate:/\b(imports?|integrate|connect|wire|bind|requires?|exports?|depends?|dependenc(y|ies)|graph)\b/i,
   navigate: /\b(find|locate|where|search|look for|show me|navigate|browse|list)\b/i,
 };
 
-function detectIntent(query) {
-  if (!query || typeof query !== 'string') return 'search';
+/**
+ * Every intent whose pattern matches, strongest first.
+ *
+ * A real request is routinely multi-intent — "fix the failing test" is both a
+ * debug task and a test task — and reporting one label discards that. Worse,
+ * the single-label version returned the FIRST key in INTENT_PATTERNS order, so
+ * `debug` permanently shadowed `test`: no query containing "fix" or "failing"
+ * could ever be labelled a test, no matter how test-shaped it was.
+ *
+ * Ranked by how many distinct terms each pattern matched, so the dominant
+ * intent leads; ties fall back to declaration order for determinism.
+ *
+ * @param {string} query
+ * @returns {string[]} matched intents, never empty (defaults to ['search'])
+ */
+function detectIntents(query) {
+  if (!query || typeof query !== 'string') return ['search'];
+  const scored = [];
+  let order = 0;
   for (const [intent, re] of Object.entries(INTENT_PATTERNS)) {
-    if (re.test(query)) return intent;
+    const hits = query.match(new RegExp(re.source, re.flags.includes('g') ? re.flags : re.flags + 'g'));
+    if (hits && hits.length) {
+      scored.push({ intent, hits: new Set(hits.map((h) => h.toLowerCase())).size, order: order });
+    }
+    order++;
   }
-  return 'search';
+  if (scored.length === 0) return ['search'];
+  scored.sort((a, b) => (b.hits - a.hits) || (a.order - b.order));
+  return scored.map((s) => s.intent);
 }
 
-module.exports = { rank, buildSigIndex, scoreFile, formatRankTable, formatRankJSON, DEFAULT_WEIGHTS, GRAPH_BOOST_AMOUNTS, CENTRALITY_BLEND_WEIGHT, detectIntent };
+/** Primary intent. Kept for callers that want a single label. */
+function detectIntent(query) {
+  return detectIntents(query)[0];
+}
+
+module.exports = { rank, buildSigIndex, scoreFile, _queryWants, detectIntents, formatRankTable, formatRankJSON, DEFAULT_WEIGHTS, GRAPH_BOOST_AMOUNTS, CENTRALITY_BLEND_WEIGHT, detectIntent };

--- a/src/retrieval/sig-index-store.js
+++ b/src/retrieval/sig-index-store.js
@@ -1,0 +1,95 @@
+'use strict';
+
+/**
+ * Complete, unbudgeted signature index for retrieval.
+ *
+ * WHY THIS EXISTS
+ * ---------------
+ * The generated context file (CLAUDE.md / AGENTS.md / copilot-instructions.md)
+ * is a BUDGETED VIEW: `applyTokenBudget` drops and collapses files so the
+ * artifact stays under `maxTokens`, because it is injected into every prompt.
+ *
+ * `buildSigIndex` used to parse that same artifact to build the ranker's index,
+ * so retrieval inherited the prompt budget. Every file the budget dropped became
+ * permanently unreachable by `sigmap ask` — no ranking change can surface a file
+ * that is not in the index. On this repo that was 53 of 155 source files (34%),
+ * and restoring them moved hit@5 from 50% to 90% on the retrieval corpus.
+ *
+ * The two artifacts have opposite requirements — the prompt file wants to be
+ * small, the index wants to be complete — so they are now separate. This store
+ * is written by `generate` BEFORE the budget is applied, and lives under
+ * `.context/` (gitignored, never injected into a prompt).
+ *
+ * Zero-dependency, bundle-safe (fs + path only).
+ */
+
+const fs = require('fs');
+const path = require('path');
+
+const INDEX_DIR = '.context';
+const INDEX_FILE = 'sig-index.json';
+const SCHEMA = 1;
+
+/** Absolute path to the retrieval index artifact. */
+function indexPath(cwd) {
+  return path.join(cwd, INDEX_DIR, INDEX_FILE);
+}
+
+/**
+ * Persist the complete signature index.
+ *
+ * @param {string} cwd
+ * @param {Array<{filePath: string, sigs: string[]}>} fileEntries - every
+ *        extracted entry, BEFORE applyTokenBudget has dropped or collapsed any.
+ * @param {{ version?: string }} [opts]
+ * @returns {{ path: string, files: number }}
+ */
+function writeFullIndex(cwd, fileEntries, opts = {}) {
+  const files = {};
+  let count = 0;
+  for (const e of fileEntries || []) {
+    if (!e || !e.filePath || !Array.isArray(e.sigs) || e.sigs.length === 0) continue;
+    const rel = path.relative(cwd, e.filePath).replace(/\\/g, '/');
+    if (!rel || rel.startsWith('..')) continue;
+    files[rel] = e.sigs;
+    count++;
+  }
+
+  const out = indexPath(cwd);
+  fs.mkdirSync(path.dirname(out), { recursive: true });
+  // Write-then-rename so a concurrent `ask` never observes a half-written index.
+  const tmp = `${out}.tmp`;
+  fs.writeFileSync(tmp, JSON.stringify({
+    schema: SCHEMA,
+    sigmapVersion: opts.version || null,
+    generated: new Date().toISOString(),
+    files,
+  }), 'utf8');
+  fs.renameSync(tmp, out);
+  return { path: out, files: count };
+}
+
+/**
+ * Load the complete signature index, or an empty Map when absent/unreadable.
+ *
+ * Deliberately NOT version-busted (unlike .sigmap-cache.json): a stale but
+ * complete index still retrieves the right files, whereas discarding it drops
+ * retrieval back to the budgeted view — the exact failure this store exists to
+ * prevent. Staleness is handled by re-running generate or by cache/freshen.
+ *
+ * @param {string} cwd
+ * @returns {Map<string, string[]>}
+ */
+function readFullIndex(cwd) {
+  const index = new Map();
+  try {
+    const data = JSON.parse(fs.readFileSync(indexPath(cwd), 'utf8'));
+    if (!data || data.schema !== SCHEMA || !data.files) return index;
+    for (const [rel, sigs] of Object.entries(data.files)) {
+      if (Array.isArray(sigs) && sigs.length > 0) index.set(rel, sigs);
+    }
+  } catch (_) { /* absent or corrupt → caller falls back to the context file */ }
+  return index;
+}
+
+module.exports = { writeFullIndex, readFullIndex, indexPath, SCHEMA, INDEX_FILE };

--- a/test/integration/callgraph-boost.test.js
+++ b/test/integration/callgraph-boost.test.js
@@ -17,6 +17,7 @@ const { spawnSync } = require('child_process');
 
 const GEN_CONTEXT = path.resolve(__dirname, '../../gen-context.js');
 const { buildCallFileGraph } = require('../../src/graph/call-graph');
+const { graphKey } = require('../../src/graph/path-key');
 const { buildFromCwd } = require('../../src/graph/builder');
 const { rank, buildSigIndex } = require('../../src/retrieval/ranker');
 
@@ -59,12 +60,16 @@ function withGoProject(fn, config) {
 test('buildCallFileGraph: bidirectional file edge where the import graph has none', () => {
   withGoProject((dir) => {
     const cg = buildCallFileGraph(dir);
-    const app = path.resolve(dir, 'src/app.go');
-    const util = path.resolve(dir, 'src/util.go');
+    // Both graphs key nodes through the one shared convention (src/graph/path-key.js).
+    // This used to read cg.forward.get(<case-preserving path>) and ig.forward.get(x)
+    // || ig.forward.get(x.toLowerCase()) — a dual probe on one graph only, which is
+    // what a silent divergence between two builders looks like from the test side.
+    const app = graphKey(path.resolve(dir, 'src/app.go'));
+    const util = graphKey(path.resolve(dir, 'src/util.go'));
     assert.deepStrictEqual(cg.forward.get(app), [util], 'app→util edge missing');
     assert.deepStrictEqual(cg.forward.get(util), [app], 'util→app (reverse) edge missing');
     const ig = buildFromCwd(dir);
-    const igNeighbors = ig.forward.get(app) || ig.forward.get(app.toLowerCase()) || [];
+    const igNeighbors = ig.forward.get(app) || [];
     assert.strictEqual(igNeighbors.length, 0, 'import graph unexpectedly has the edge — fixture invalid');
   });
 });

--- a/test/integration/retrieval-index.test.js
+++ b/test/integration/retrieval-index.test.js
@@ -220,21 +220,58 @@ test('A11: a penalty never fires on the category the query asked for', () => {
     'test files surfaced for a non-test query — the penalty stopped working');
 });
 
-test('A12: call-graph boost survives an uppercase repo path', () => {
-  // The callgraph-boost fixture runs in an all-lowercase temp dir, so a
-  // case-sensitivity bug passes there and fails on any real checkout under
-  // /Users or C:\\Users. This exercises the REAL repo path on purpose.
-  assert.ok(/[A-Z]/.test(ROOT), 'this guard needs a repo path containing an uppercase letter');
-  const { buildSigIndex, rank } = require('../../src/retrieval/ranker');
-  const { buildCallFileGraph } = require('../../src/graph/call-graph');
-  const index = buildSigIndex(ROOT);
-  let callGraph = null;
-  try { callGraph = buildCallFileGraph(ROOT); } catch (_) { return; }
-  if (!callGraph || callGraph.forward.size === 0) return;
-  const boosted = rank('rank files against a query', index, { topK: 25, cwd: ROOT, callGraph, learned: false })
-    .filter((r) => r.signals && r.signals.callGraphBoost);
-  assert.ok(boosted.length > 0,
-    'no file received a call-graph boost on an uppercase path — key spaces diverged again');
+test('A12: graph boosts survive an uppercase repo path', () => {
+  // The callgraph-boost fixture builds under a LOWERCASE temp dir, which is
+  // exactly why a case-sensitivity bug lived there undetected: builder.js
+  // lowercases node keys, the ranker looked up case-preserving paths, and on an
+  // all-lowercase path those two happen to agree. A real checkout does not look
+  // like that (/Users/..., C:\\Users\\...).
+  //
+  // This used to assert on the AMBIENT repo path, which made the guard pass on
+  // macOS and HARD-FAIL on a Linux CI runner at /home/runner/work/... — the
+  // condition has to be forced, not borrowed from the environment.
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'SigMap-Upper-'));
+  try {
+    assert.ok(/[A-Z]/.test(dir), 'fixture path must contain an uppercase letter');
+    fs.mkdirSync(path.join(dir, 'src'));
+    fs.writeFileSync(path.join(dir, 'src', 'util.js'),
+      'function helperRoutine(value) { return value + 1; }\nmodule.exports = { helperRoutine };\n');
+    fs.writeFileSync(path.join(dir, 'src', 'app.js'),
+      "const { helperRoutine } = require('./util');\nfunction runServer(port) { return helperRoutine(port); }\nmodule.exports = { runServer };\n");
+    // Filler. Hub suppression treats any file imported by >=20% of the graph as a
+    // hub and refuses to boost it — in a two-file fixture that is one importer,
+    // so the boost could never fire and the guard would fail for the wrong reason.
+    for (let i = 0; i < 8; i++) {
+      fs.writeFileSync(path.join(dir, 'src', `filler${i}.js`),
+        `function unrelatedThing${i}(a, b) { return a - b; }\nmodule.exports = { unrelatedThing${i} };\n`);
+    }
+    execSync(`node ${GEN_CONTEXT}`, { cwd: dir, stdio: 'pipe' });
+
+    delete require.cache[require.resolve('../../src/retrieval/ranker')];
+    const { buildSigIndex, rank } = require('../../src/retrieval/ranker');
+    const { buildFromCwd } = require('../../src/graph/builder');
+    const { buildCallFileGraph } = require('../../src/graph/call-graph');
+
+    const index = buildSigIndex(dir);
+    assert.ok(index.size > 0, 'fixture produced no index');
+
+    const graph = buildFromCwd(dir);
+    const impBoosted = rank('run server port', index, { topK: 5, cwd: dir, graph, learned: false })
+      .filter((r) => r.signals && r.signals.graphBoost);
+    assert.ok(impBoosted.length > 0,
+      'import-graph boost did not fire on an uppercase path — ranker and graph key spaces diverged');
+
+    let callGraph = null;
+    try { callGraph = buildCallFileGraph(dir); } catch (_) { /* optional */ }
+    if (callGraph && callGraph.forward.size > 0) {
+      const cgBoosted = rank('run server port', index, { topK: 5, cwd: dir, callGraph, learned: false })
+        .filter((r) => r.signals && r.signals.callGraphBoost);
+      assert.ok(cgBoosted.length > 0,
+        'call-graph boost did not fire on an uppercase path — key spaces diverged');
+    }
+  } finally {
+    fs.rmSync(dir, { recursive: true, force: true });
+  }
 });
 
 test('A13: both graph builders key nodes through the same convention', () => {

--- a/test/integration/retrieval-index.test.js
+++ b/test/integration/retrieval-index.test.js
@@ -1,0 +1,270 @@
+'use strict';
+
+/**
+ * Retrieval-index completeness.
+ *
+ * REGRESSION GUARD. The generated context file is a token-BUDGETED view meant
+ * for prompt injection; the ranker's index must NOT inherit that budget. When
+ * they shared one artifact, every file `applyTokenBudget` dropped became
+ * permanently unreachable by `sigmap ask` — no ranking change can surface a
+ * file that is not indexed. These tests pin the separation so a future budget
+ * change cannot silently starve retrieval again.
+ */
+
+const fs = require('fs');
+const path = require('path');
+const os = require('os');
+const assert = require('assert');
+const { execSync } = require('child_process');
+
+const ROOT = path.resolve(__dirname, '../..');
+const GEN_CONTEXT = path.join(ROOT, 'gen-context.js');
+
+let passed = 0;
+let failed = 0;
+
+function test(name, fn) {
+  try {
+    fn();
+    console.log(`  PASS  ${name}`);
+    passed++;
+  } catch (err) {
+    console.log(`  FAIL  ${name}: ${err.message}`);
+    failed++;
+  }
+}
+
+function withTempProject(fn) {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'sigmap-idx-'));
+  try { fn(dir); } finally { fs.rmSync(dir, { recursive: true, force: true }); }
+}
+
+function runGenerate(dir, args = '') {
+  return execSync(`node ${GEN_CONTEXT} ${args}`, { cwd: dir, encoding: 'utf8', stdio: 'pipe' });
+}
+
+/** A source file large enough that a tight budget must drop some of them. */
+function writeJsFile(filePath, fnCount, prefix) {
+  let content = '';
+  for (let i = 0; i < fnCount; i++) {
+    content += `function ${prefix}Handler${i}(alpha, beta, gamma) { return alpha + beta + gamma; }\n`;
+  }
+  fs.mkdirSync(path.dirname(filePath), { recursive: true });
+  fs.writeFileSync(filePath, content);
+}
+
+/**
+ * A project deliberately far over budget, so applyTokenBudget must drop files.
+ * Returns the list of repo-relative source paths written.
+ */
+function buildOverBudgetProject(dir, fileCount = 24) {
+  const rels = [];
+  for (let i = 0; i < fileCount; i++) {
+    const rel = `src/module${i}/feature${i}.js`;
+    writeJsFile(path.join(dir, rel), 22, `mod${i}`);
+    rels.push(rel);
+  }
+  fs.writeFileSync(path.join(dir, 'package.json'), JSON.stringify({
+    name: 'idx-fixture', version: '1.0.0', main: 'entrypoint.js',
+  }));
+  // A declared entrypoint OUTSIDE srcDirs — must still be indexed.
+  writeJsFile(path.join(dir, 'entrypoint.js'), 3, 'entry');
+  fs.writeFileSync(path.join(dir, 'gen-context.config.json'), JSON.stringify({
+    srcDirs: ['src'], outputs: ['copilot'], secretScan: false, maxTokens: 900,
+  }));
+  return rels;
+}
+
+// ---------------------------------------------------------------------------
+
+console.log('\nretrieval-index:');
+
+test('A1: generate writes a complete retrieval index artifact', () => {
+  withTempProject((dir) => {
+    buildOverBudgetProject(dir);
+    runGenerate(dir);
+    const artifact = path.join(dir, '.context', 'sig-index.json');
+    assert.ok(fs.existsSync(artifact), 'expected .context/sig-index.json to exist');
+    const data = JSON.parse(fs.readFileSync(artifact, 'utf8'));
+    assert.strictEqual(data.schema, 1, 'schema version should be 1');
+    assert.ok(Object.keys(data.files).length > 0, 'index should not be empty');
+  });
+});
+
+test('A2: the budget actually drops files from the prompt artifact (fixture is valid)', () => {
+  withTempProject((dir) => {
+    const rels = buildOverBudgetProject(dir);
+    runGenerate(dir);
+    const ctx = fs.readFileSync(path.join(dir, '.github', 'copilot-instructions.md'), 'utf8');
+    const inPrompt = rels.filter((r) => ctx.includes(`### ${r}`));
+    assert.ok(inPrompt.length < rels.length,
+      `fixture must be over budget: all ${rels.length} files survived the prompt budget`);
+  });
+});
+
+test('A3: the retrieval index keeps EVERY source file the budget dropped', () => {
+  withTempProject((dir) => {
+    const rels = buildOverBudgetProject(dir);
+    runGenerate(dir);
+    const data = JSON.parse(fs.readFileSync(path.join(dir, '.context', 'sig-index.json'), 'utf8'));
+    const missing = rels.filter((r) => !data.files[r]);
+    assert.strictEqual(missing.length, 0,
+      `retrieval index is missing ${missing.length} budget-dropped file(s): ${missing.slice(0, 3).join(', ')}`);
+  });
+});
+
+test('A4: buildSigIndex() sees every scanned file, not just the budgeted view', () => {
+  withTempProject((dir) => {
+    const rels = buildOverBudgetProject(dir);
+    runGenerate(dir);
+    delete require.cache[require.resolve('../../src/retrieval/ranker')];
+    const { buildSigIndex } = require('../../src/retrieval/ranker');
+    const index = buildSigIndex(dir);
+    const missing = rels.filter((r) => !index.has(r));
+    assert.strictEqual(missing.length, 0,
+      `buildSigIndex dropped ${missing.length} file(s) — retrieval is inheriting the prompt budget`);
+  });
+});
+
+test('A5: a budget-dropped file is still retrievable by the ranker', () => {
+  withTempProject((dir) => {
+    const rels = buildOverBudgetProject(dir);
+    runGenerate(dir);
+    const ctx = fs.readFileSync(path.join(dir, '.github', 'copilot-instructions.md'), 'utf8');
+    const dropped = rels.find((r) => !ctx.includes(`### ${r}`));
+    assert.ok(dropped, 'fixture should have at least one dropped file');
+    delete require.cache[require.resolve('../../src/retrieval/ranker')];
+    const { buildSigIndex, rank } = require('../../src/retrieval/ranker');
+    const index = buildSigIndex(dir);
+    const n = dropped.match(/module(\d+)/)[1];
+    const results = rank(`mod${n}Handler`, index, { topK: 5, cwd: dir });
+    assert.ok(results.some((r) => r.file === dropped),
+      `dropped file ${dropped} did not rank for its own symbol — it is unreachable`);
+  });
+});
+
+test('A6: a declared package.json entrypoint outside srcDirs is indexed', () => {
+  withTempProject((dir) => {
+    buildOverBudgetProject(dir);
+    runGenerate(dir);
+    const data = JSON.parse(fs.readFileSync(path.join(dir, '.context', 'sig-index.json'), 'utf8'));
+    assert.ok(data.files['entrypoint.js'],
+      'package.json "main" outside srcDirs should still be indexed');
+  });
+});
+
+test('A7: scoring weights are load-bearing (guards the dead-weights regression)', () => {
+  // DEFAULT_WEIGHTS and every intent profile were once computed and discarded,
+  // so ranking was identical for any weights. Setting them all to zero must
+  // change SOMETHING, or the weight system is dead config again.
+  const { buildSigIndex, rank } = require('../../src/retrieval/ranker');
+  const index = buildSigIndex(ROOT);
+  assert.ok(index.size > 0, 'repo index should be non-empty');
+  const zero = { exactToken: 0, symbolMatch: 0, prefixMatch: 0, pathMatch: 0, recencyBoost: 1, graphBoost: 0 };
+  const q = 'rank files against a query';
+  const a = rank(q, index, { topK: 10, cwd: ROOT }).map((r) => r.score.toFixed(6)).join('|');
+  const b = rank(q, index, { topK: 10, cwd: ROOT, weights: zero }).map((r) => r.score.toFixed(6)).join('|');
+  assert.notStrictEqual(a, b, 'zeroing every weight changed nothing — scoring weights are dead config');
+});
+
+test('A8: graph boost lookups match the graph key space (case-normalisation guard)', () => {
+  // The graph builders lowercase every node key; the ranker used path.resolve()
+  // which preserves case, so on any repo path containing an uppercase letter
+  // every lookup missed and the boost was silently inert.
+  const { buildSigIndex, rank } = require('../../src/retrieval/ranker');
+  const { buildFromCwd } = require('../../src/graph/builder');
+  const index = buildSigIndex(ROOT);
+  const graph = buildFromCwd(ROOT);
+  const boosted = rank('MCP server tool definitions', index, { topK: 10, cwd: ROOT, graph })
+    .filter((r) => r.signals && r.signals.graphBoost);
+  assert.ok(boosted.length > 0,
+    'no file received a graph boost — the ranker and graph key spaces have diverged again');
+});
+
+test('A9: module-doc prose is indexed but never rendered into the prompt', () => {
+  const { readFullIndex } = require('../../src/retrieval/sig-index-store');
+  const index = readFullIndex(ROOT);
+  const withDoc = [...index.values()].filter((sigs) => sigs[0] && sigs[0].startsWith('# module:'));
+  assert.ok(withDoc.length > 20, `only ${withDoc.length} files carry a module doc — enrichment is not running`);
+  // The prompt artifact is token-budgeted; prose belongs only in the index.
+  const ctx = fs.readFileSync(path.join(ROOT, 'CLAUDE.md'), 'utf8');
+  assert.ok(!ctx.includes('# module:'), 'module-doc prose leaked into the generated context file');
+});
+
+test('A10: test files are reachable by the ranker but absent from the prompt', () => {
+  const { buildSigIndex } = require('../../src/retrieval/ranker');
+  const index = buildSigIndex(ROOT);
+  const tests = [...index.keys()].filter((f) => /^tests?\//.test(f));
+  assert.ok(tests.length > 0, 'no test file is indexed — "where are the tests for X" is unanswerable');
+  const ctx = fs.readFileSync(path.join(ROOT, 'CLAUDE.md'), 'utf8');
+  const leaked = tests.filter((f) => ctx.includes('### ' + f));
+  assert.strictEqual(leaked.length, 0, `${leaked.length} test file(s) leaked into the prompt artifact`);
+});
+
+test('A11: a penalty never fires on the category the query asked for', () => {
+  const { _queryWants } = require('../../src/retrieval/ranker');
+  const { tokenize } = require('../../src/retrieval/tokenizer');
+  // detectIntent cannot express this: it is first-match-wins and `debug`
+  // precedes `test`, so this query classifies as debug and never sees a test.
+  assert.strictEqual(_queryWants(tokenize('fix the failing test')).tests, true);
+  assert.strictEqual(_queryWants(tokenize('update the readme')).docs, true);
+  assert.strictEqual(_queryWants(tokenize('rank files by relevance')).tests, false);
+
+  const { buildSigIndex, rank } = require('../../src/retrieval/ranker');
+  const index = buildSigIndex(ROOT);
+  const asked = rank('where are the tests for the ranker', index, { topK: 5, cwd: ROOT, learned: false });
+  assert.ok(asked.some((r) => /^tests?\//.test(r.file)),
+    'a test-seeking query returned no test file — the penalty is fighting the query');
+  const notAsked = rank('rank files by relevance', index, { topK: 5, cwd: ROOT, learned: false });
+  assert.ok(notAsked.every((r) => !/^tests?\//.test(r.file)),
+    'test files surfaced for a non-test query — the penalty stopped working');
+});
+
+test('A12: call-graph boost survives an uppercase repo path', () => {
+  // The callgraph-boost fixture runs in an all-lowercase temp dir, so a
+  // case-sensitivity bug passes there and fails on any real checkout under
+  // /Users or C:\\Users. This exercises the REAL repo path on purpose.
+  assert.ok(/[A-Z]/.test(ROOT), 'this guard needs a repo path containing an uppercase letter');
+  const { buildSigIndex, rank } = require('../../src/retrieval/ranker');
+  const { buildCallFileGraph } = require('../../src/graph/call-graph');
+  const index = buildSigIndex(ROOT);
+  let callGraph = null;
+  try { callGraph = buildCallFileGraph(ROOT); } catch (_) { return; }
+  if (!callGraph || callGraph.forward.size === 0) return;
+  const boosted = rank('rank files against a query', index, { topK: 25, cwd: ROOT, callGraph, learned: false })
+    .filter((r) => r.signals && r.signals.callGraphBoost);
+  assert.ok(boosted.length > 0,
+    'no file received a call-graph boost on an uppercase path — key spaces diverged again');
+});
+
+test('A13: both graph builders key nodes through the same convention', () => {
+  // These diverged silently for a long time — builder lowercased, call-graph did
+  // not — which disabled the import boost on any uppercase repo path and then
+  // made a fix for one graph break the other.
+  const { graphKey } = require('../../src/graph/path-key');
+  const { buildFromCwd } = require('../../src/graph/builder');
+  const { buildCallFileGraph } = require('../../src/graph/call-graph');
+  const imp = [...buildFromCwd(ROOT).forward.keys()];
+  assert.ok(imp.length > 0, 'import graph is empty');
+  assert.ok(imp.every((k) => k === graphKey(k)), 'import graph keys are not canonical');
+  let call = [];
+  try { call = [...buildCallFileGraph(ROOT).forward.keys()]; } catch (_) { return; }
+  assert.ok(call.every((k) => k === graphKey(k)), 'call graph keys are not canonical');
+});
+
+test('A14: intent detection is multi-label and does not shadow', () => {
+  const { detectIntents, detectIntent } = require('../../src/retrieval/ranker');
+  // Single-label first-match-wins meant `debug` permanently shadowed `test`.
+  const both = detectIntents('fix the failing test');
+  assert.ok(both.includes('debug') && both.includes('test'),
+    `expected both debug and test, got ${JSON.stringify(both)}`);
+  // \btest\b does not match "tests" — this fell through to 'search' entirely.
+  assert.ok(detectIntents('write unit tests for the ranker').includes('test'),
+    'plural "tests" still matches no intent');
+  assert.strictEqual(detectIntent('rank files'), detectIntents('rank files')[0],
+    'primary label must be the head of the multi-label list');
+});
+
+console.log('');
+console.log(`retrieval-index: ${passed} passed, ${failed} failed`);
+if (failed > 0) process.exit(1);

--- a/version.json
+++ b/version.json
@@ -5,7 +5,7 @@
   "languages": 33,
   "extractors": 43,
   "mcp_tools": 21,
-  "tests": 138,
+  "tests": 139,
   "metrics": {
     "hit_at_5": 0.811,
     "baseline_hit_at_5": 0.136,


### PR DESCRIPTION
Closes #546.

## What was wrong

`buildSigIndex` parsed the **token-budgeted** context file, so retrieval
inherited the prompt budget: every file `applyTokenBudget` dropped to fit
`maxTokens` was unreachable at any rank — **53 of 155 source files** here. No
ranking change can surface a file that is not in the index.

Most of the ranking stack meant to compensate was also inert:

| feature | state before |
|---|---|
| import-graph boost | never passed in `ask`; and keys mismatched (builder lowercases, call-graph did not) |
| call-graph boost | same key mismatch |
| `INTENT_WEIGHTS` | `scoreFile`'s score discarded — zeroing every weight changed no ranking |
| negative penalties | fired on 0 of 158 indexed files |
| test files | not indexed at all |
| eval runner | had its own `rank` **and** `buildSigIndex`, so none of the above was visible |

## What changed

**Index, never injected into a prompt.** Complete index written to
`.context/sig-index.json` before `applyTokenBudget`, for every strategy, merged
as the base so uncollapsed signatures win. Enriched with module-doc prose and
test files. Declared `package.json` entrypoints outside `srcDirs` are scanned.

**Ranking.** One shared graph key convention (`src/graph/path-key.js`).
`scoreFile`'s signal is blended into the score instead of discarded. Module-doc
prose scored as its own weighted BM25F field. Line anchors stripped wherever
they appear — doc hints follow the anchor, so 27% of signatures were leaking
line numbers into the term space. Penalties no longer fire on the category the
query asked for. Intent detection is multi-label and matches plurals.

**Measurement.** Runner uses production `rank`/`buildSigIndex`. Two corpora:
`retrieval-hard.jsonl` (90 leak-free tasks) and `retrieval-mined.jsonl` (mined
from commit subjects + the files those commits touched — **nobody tuning the
ranker authored them**). `check-corpus.mjs` adds a verbatim 4-gram check on top
of basename leakage. `run-retrieval-gate.mjs` gates CI on floor, regression and
hygiene.

## Numbers

```
                          before    after
self-authored (90 tasks)   45.0%    76.7%   hit@5
independent   (23 tasks)      —     60.9%   hit@5
```

The independent corpus is the honest one. The bias ladder it exposes —
**leaky 90.0% / self-authored 76.7% / independent 60.9%** — is why it exists and
why it is gated. It is also small (1 task = 4.3pp) and the defensible miner
parameter range spans 53–73%, so it is documented as a band, not a point.

Prompt artifacts do not grow: `CLAUDE.md` stays ~55KB. The 176KB index lives in
gitignored `.context/`.

## Rejected after measurement

Recorded in source with reasons so they are not re-derived: same-line locality,
full per-symbol doc-hint recovery, pseudo-relevance feedback, and a name/body
BM25F split — the last raised hit@5 by one task while lowering hit@1, hit@3 and
MRR, and would have passed a hit@5-only review.

## Verification

- unit 23 · integration **133 · 0 failed** · python OK
- 14 new guards in `test/integration/retrieval-index.test.js`, each verified to
  **fail when its bug is reintroduced**
- bundle reproducible from `src/` (154 modules); no metrics drift
- supply-chain audit: no shell spawns · no install scripts · `main` exports an
  API · no fingerprinting

## Note for review

`test:integration` now runs `test/integration/all.js` — the hardcoded subset it
ran before diverged from CI and was hiding three failures.
