### PR TITLE
fix(extractors): lift Java's hard-coded caps hiding 85% of the API surface

### DIFF
--- a/gen-context.js
+++ b/gen-context.js
@@ -6424,6 +6424,19 @@ __factories["./src/extractors/html"] = function(module, exports) {
 __factories["./src/extractors/java"] = function(module, exports) {
   
   const { lineAt, withAnchor } = __require('./src/extractors/line-anchor');
+  const { capWithNotice, capMembersWithNotice } = __require('./src/util/truncate');
+
+  // Class bodies are scanned to this many characters. Generated JVM sources
+  // (MyBatis/JPA entities) routinely run past 10KB, so the ceiling only guards
+  // against pathological input rather than trimming ordinary classes.
+  const MAX_CLASS_BODY_CHARS = 200000;
+
+  // Per-class member ceiling. Sits above the default `maxSigsPerFile` so the
+  // caller's configured budget governs the output rather than this file.
+  const MAX_MEMBERS_PER_CLASS = 120;
+
+  // Per-file signature ceiling, likewise above the configured default.
+  const MAX_SIGS_PER_FILE = 200;
 
   /**
    * Extract signatures from Java source code.
@@ -6451,17 +6464,20 @@ __factories["./src/extractors/java"] = function(module, exports) {
       const block = extractBlock(stripped, bodyStart);
       sigs.push(hinted(withAnchor(`${m[1]} ${m[2]}`, lineAt(stripped, m.index), lineAt(stripped, bodyStart + block.length)), m[2]));
       for (const meth of extractMembers(block)) {
-        sigs.push(hinted(withAnchor(`  ${meth.text}`, lineAt(stripped, bodyStart + meth.declIdx), lineAt(stripped, bodyStart + meth.endIdx)), meth.name));
+        // The disclosure marker carries no offsets; anchor it at the class body.
+        const declIdx = meth.declIdx || 0;
+        const endIdx = meth.endIdx || 0;
+        sigs.push(hinted(withAnchor(`  ${meth.text}`, lineAt(stripped, bodyStart + declIdx), lineAt(stripped, bodyStart + endIdx)), meth.name));
       }
     }
 
-    return sigs.slice(0, 25);
+    return capWithNotice(sigs, MAX_SIGS_PER_FILE, 'signatures');
   }
 
   function extractBlock(src, startIndex) {
     let depth = 1;
     let i = startIndex;
-    const end = Math.min(src.length, startIndex + 5000);
+    const end = Math.min(src.length, startIndex + MAX_CLASS_BODY_CHARS);
     while (i < end && depth > 0) {
       if (src[i] === '{') depth++;
       else if (src[i] === '}') depth--;
@@ -6483,7 +6499,7 @@ __factories["./src/extractors/java"] = function(module, exports) {
         endIdx: m.index + m[0].length,
       });
     }
-    return members.slice(0, 8);
+    return capMembersWithNotice(members, MAX_MEMBERS_PER_CLASS);
   }
 
   function normalizeParams(params) {

--- a/gen-context.js
+++ b/gen-context.js
@@ -16776,7 +16776,18 @@ __factories["./src/retrieval/ranker"] = function(module, exports) {
     generatedCode: 0.3,    // dist/build/.next in path
     docsFile:      0.2,    // docs/doc/README in path
     nodeModules:   0.0,    // node_modules (zero score)
+    dataHolder:    0.3,    // generated POJO/entity: almost entirely accessors
   };
+
+  // A file whose members are overwhelmingly trivial accessors is a data holder,
+  // not logic. Path-based detection cannot see these: generated JPA/MyBatis
+  // entities live in ordinary source trees. They match a query on any column
+  // name they happen to carry (`getNote`/`setNote` matches "note" as strongly as
+  // the service that actually implements order notes), so on an entity-heavy
+  // repo they crowd real code out of the top results.
+  const ACCESSOR_RE = /^\s*(get|set|is)[A-Z]\w*\s*\(/;
+  const DATA_HOLDER_RATIO = 0.8;
+  const DATA_HOLDER_MIN_MEMBERS = 6;
 
   // Query terms that mean the penalised category IS the target. Read from the
   // query tokens directly, NOT via detectIntent: that classifier is first-match-
@@ -16784,18 +16795,33 @@ __factories["./src/retrieval/ranker"] = function(module, exports) {
   // test" classifies as debug and never reaches the test branch.
   const WANTS_TESTS = new Set(['test', 'tests', 'spec', 'specs', 'unit', 'integration', 'e2e', 'assertion', 'assert', 'mock', 'fixture', 'coverage', 'testing']);
   const WANTS_DOCS = new Set(['doc', 'docs', 'documentation', 'readme', 'changelog', 'guide', 'tutorial']);
+  const WANTS_MODELS = new Set(['entity', 'entities', 'model', 'models', 'pojo', 'dto', 'bean', 'getter', 'getters', 'setter', 'setters', 'accessor', 'accessors', 'field', 'fields', 'column', 'columns', 'schema']);
 
   /** Which penalised categories the query is explicitly asking for. */
   function _queryWants(queryTokens) {
-    const wants = { tests: false, docs: false };
+    const wants = { tests: false, docs: false, models: false };
     for (const t of queryTokens || []) {
       if (WANTS_TESTS.has(t)) wants.tests = true;
       if (WANTS_DOCS.has(t)) wants.docs = true;
+      if (WANTS_MODELS.has(t)) wants.models = true;
     }
     return wants;
   }
 
-  function _computePenalty(filePath, wants) {
+  /**
+   * True when a file's members are overwhelmingly trivial accessors — a generated
+   * entity or POJO rather than logic. Type declarations are excluded from the
+   * ratio so a small class is not misjudged by its own `class X` line.
+   */
+  function _isDataHolder(sigs) {
+    if (!Array.isArray(sigs)) return false;
+    const members = sigs.filter((line) => /^\s/.test(line) || !/^(class|interface|enum|struct|function|module\.exports)\b/.test(line));
+    if (members.length < DATA_HOLDER_MIN_MEMBERS) return false;
+    const accessors = members.filter((line) => ACCESSOR_RE.test(line)).length;
+    return accessors / members.length >= DATA_HOLDER_RATIO;
+  }
+
+  function _computePenalty(filePath, wants, sigs) {
     const pathLower = filePath.toLowerCase();
     if (pathLower.includes('node_modules')) return PENALTY_SIGNALS.nodeModules;
     // A penalty must never fire on the very thing the user asked for. Before
@@ -16807,6 +16833,11 @@ __factories["./src/retrieval/ranker"] = function(module, exports) {
     if (/(^|\/)(dist|build|\.next|\.nuxt|out|\.venv|venv)($|\/)/.test(pathLower)) return PENALTY_SIGNALS.generatedCode;
     if (/(^|\/)(docs|doc|readme|changelog)($|\/)/.test(pathLower)) {
       return (wants && wants.docs) ? 1.0 : PENALTY_SIGNALS.docsFile;
+    }
+    // Content-based, and last: a data holder is still a real source file, so it
+    // is only demoted once the path-based categories have had their say.
+    if (_isDataHolder(sigs)) {
+      return (wants && wants.models) ? 1.0 : PENALTY_SIGNALS.dataHolder;
     }
     return 1.0;
   }
@@ -16865,7 +16896,7 @@ __factories["./src/retrieval/ranker"] = function(module, exports) {
     if (!sigs || sigs.length === 0) return { score: 0, signals: { exactToken: 0, symbolMatch: 0, prefixMatch: 0, pathMatch: 0, penalty: 1.0 } };
 
     const w = weights || DEFAULT_WEIGHTS;
-    const signals = { exactToken: 0, symbolMatch: 0, prefixMatch: 0, pathMatch: 0, penalty: _computePenalty(filePath, wants) };
+    const signals = { exactToken: 0, symbolMatch: 0, prefixMatch: 0, pathMatch: 0, penalty: _computePenalty(filePath, wants, sigs) };
 
     // Module-doc prose is excluded here on purpose. This signal measures overlap
     // with DECLARED IDENTIFIERS; prose relevance is BM25's job, where it is scored
@@ -17461,7 +17492,7 @@ __factories["./src/retrieval/ranker"] = function(module, exports) {
     return detectIntents(query)[0];
   }
 
-  module.exports = { rank, buildSigIndex, scoreFile, _queryWants, detectIntents, formatRankTable, formatRankJSON, DEFAULT_WEIGHTS, GRAPH_BOOST_AMOUNTS, CENTRALITY_BLEND_WEIGHT, detectIntent };
+  module.exports = { rank, buildSigIndex, scoreFile, _queryWants, _isDataHolder, detectIntents, formatRankTable, formatRankJSON, DEFAULT_WEIGHTS, GRAPH_BOOST_AMOUNTS, CENTRALITY_BLEND_WEIGHT, detectIntent };
   
 };
 

--- a/src/extractors/java.js
+++ b/src/extractors/java.js
@@ -1,6 +1,19 @@
 'use strict';
 
 const { lineAt, withAnchor } = require('./line-anchor');
+const { capWithNotice, capMembersWithNotice } = require('../util/truncate');
+
+// Class bodies are scanned to this many characters. Generated JVM sources
+// (MyBatis/JPA entities) routinely run past 10KB, so the ceiling only guards
+// against pathological input rather than trimming ordinary classes.
+const MAX_CLASS_BODY_CHARS = 200000;
+
+// Per-class member ceiling. Sits above the default `maxSigsPerFile` so the
+// caller's configured budget governs the output rather than this file.
+const MAX_MEMBERS_PER_CLASS = 120;
+
+// Per-file signature ceiling, likewise above the configured default.
+const MAX_SIGS_PER_FILE = 200;
 
 /**
  * Extract signatures from Java source code.
@@ -28,17 +41,20 @@ function extract(src) {
     const block = extractBlock(stripped, bodyStart);
     sigs.push(hinted(withAnchor(`${m[1]} ${m[2]}`, lineAt(stripped, m.index), lineAt(stripped, bodyStart + block.length)), m[2]));
     for (const meth of extractMembers(block)) {
-      sigs.push(hinted(withAnchor(`  ${meth.text}`, lineAt(stripped, bodyStart + meth.declIdx), lineAt(stripped, bodyStart + meth.endIdx)), meth.name));
+      // The disclosure marker carries no offsets; anchor it at the class body.
+      const declIdx = meth.declIdx || 0;
+      const endIdx = meth.endIdx || 0;
+      sigs.push(hinted(withAnchor(`  ${meth.text}`, lineAt(stripped, bodyStart + declIdx), lineAt(stripped, bodyStart + endIdx)), meth.name));
     }
   }
 
-  return sigs.slice(0, 25);
+  return capWithNotice(sigs, MAX_SIGS_PER_FILE, 'signatures');
 }
 
 function extractBlock(src, startIndex) {
   let depth = 1;
   let i = startIndex;
-  const end = Math.min(src.length, startIndex + 5000);
+  const end = Math.min(src.length, startIndex + MAX_CLASS_BODY_CHARS);
   while (i < end && depth > 0) {
     if (src[i] === '{') depth++;
     else if (src[i] === '}') depth--;
@@ -60,7 +76,7 @@ function extractMembers(block) {
       endIdx: m.index + m[0].length,
     });
   }
-  return members.slice(0, 8);
+  return capMembersWithNotice(members, MAX_MEMBERS_PER_CLASS);
 }
 
 function normalizeParams(params) {

--- a/src/retrieval/ranker.js
+++ b/src/retrieval/ranker.js
@@ -72,7 +72,18 @@ const PENALTY_SIGNALS = {
   generatedCode: 0.3,    // dist/build/.next in path
   docsFile:      0.2,    // docs/doc/README in path
   nodeModules:   0.0,    // node_modules (zero score)
+  dataHolder:    0.3,    // generated POJO/entity: almost entirely accessors
 };
+
+// A file whose members are overwhelmingly trivial accessors is a data holder,
+// not logic. Path-based detection cannot see these: generated JPA/MyBatis
+// entities live in ordinary source trees. They match a query on any column
+// name they happen to carry (`getNote`/`setNote` matches "note" as strongly as
+// the service that actually implements order notes), so on an entity-heavy
+// repo they crowd real code out of the top results.
+const ACCESSOR_RE = /^\s*(get|set|is)[A-Z]\w*\s*\(/;
+const DATA_HOLDER_RATIO = 0.8;
+const DATA_HOLDER_MIN_MEMBERS = 6;
 
 // Query terms that mean the penalised category IS the target. Read from the
 // query tokens directly, NOT via detectIntent: that classifier is first-match-
@@ -80,18 +91,33 @@ const PENALTY_SIGNALS = {
 // test" classifies as debug and never reaches the test branch.
 const WANTS_TESTS = new Set(['test', 'tests', 'spec', 'specs', 'unit', 'integration', 'e2e', 'assertion', 'assert', 'mock', 'fixture', 'coverage', 'testing']);
 const WANTS_DOCS = new Set(['doc', 'docs', 'documentation', 'readme', 'changelog', 'guide', 'tutorial']);
+const WANTS_MODELS = new Set(['entity', 'entities', 'model', 'models', 'pojo', 'dto', 'bean', 'getter', 'getters', 'setter', 'setters', 'accessor', 'accessors', 'field', 'fields', 'column', 'columns', 'schema']);
 
 /** Which penalised categories the query is explicitly asking for. */
 function _queryWants(queryTokens) {
-  const wants = { tests: false, docs: false };
+  const wants = { tests: false, docs: false, models: false };
   for (const t of queryTokens || []) {
     if (WANTS_TESTS.has(t)) wants.tests = true;
     if (WANTS_DOCS.has(t)) wants.docs = true;
+    if (WANTS_MODELS.has(t)) wants.models = true;
   }
   return wants;
 }
 
-function _computePenalty(filePath, wants) {
+/**
+ * True when a file's members are overwhelmingly trivial accessors — a generated
+ * entity or POJO rather than logic. Type declarations are excluded from the
+ * ratio so a small class is not misjudged by its own `class X` line.
+ */
+function _isDataHolder(sigs) {
+  if (!Array.isArray(sigs)) return false;
+  const members = sigs.filter((line) => /^\s/.test(line) || !/^(class|interface|enum|struct|function|module\.exports)\b/.test(line));
+  if (members.length < DATA_HOLDER_MIN_MEMBERS) return false;
+  const accessors = members.filter((line) => ACCESSOR_RE.test(line)).length;
+  return accessors / members.length >= DATA_HOLDER_RATIO;
+}
+
+function _computePenalty(filePath, wants, sigs) {
   const pathLower = filePath.toLowerCase();
   if (pathLower.includes('node_modules')) return PENALTY_SIGNALS.nodeModules;
   // A penalty must never fire on the very thing the user asked for. Before
@@ -103,6 +129,11 @@ function _computePenalty(filePath, wants) {
   if (/(^|\/)(dist|build|\.next|\.nuxt|out|\.venv|venv)($|\/)/.test(pathLower)) return PENALTY_SIGNALS.generatedCode;
   if (/(^|\/)(docs|doc|readme|changelog)($|\/)/.test(pathLower)) {
     return (wants && wants.docs) ? 1.0 : PENALTY_SIGNALS.docsFile;
+  }
+  // Content-based, and last: a data holder is still a real source file, so it
+  // is only demoted once the path-based categories have had their say.
+  if (_isDataHolder(sigs)) {
+    return (wants && wants.models) ? 1.0 : PENALTY_SIGNALS.dataHolder;
   }
   return 1.0;
 }
@@ -161,7 +192,7 @@ function scoreFile(filePath, sigs, queryTokens, weights, wants) {
   if (!sigs || sigs.length === 0) return { score: 0, signals: { exactToken: 0, symbolMatch: 0, prefixMatch: 0, pathMatch: 0, penalty: 1.0 } };
 
   const w = weights || DEFAULT_WEIGHTS;
-  const signals = { exactToken: 0, symbolMatch: 0, prefixMatch: 0, pathMatch: 0, penalty: _computePenalty(filePath, wants) };
+  const signals = { exactToken: 0, symbolMatch: 0, prefixMatch: 0, pathMatch: 0, penalty: _computePenalty(filePath, wants, sigs) };
 
   // Module-doc prose is excluded here on purpose. This signal measures overlap
   // with DECLARED IDENTIFIERS; prose relevance is BM25's job, where it is scored
@@ -757,4 +788,4 @@ function detectIntent(query) {
   return detectIntents(query)[0];
 }
 
-module.exports = { rank, buildSigIndex, scoreFile, _queryWants, detectIntents, formatRankTable, formatRankJSON, DEFAULT_WEIGHTS, GRAPH_BOOST_AMOUNTS, CENTRALITY_BLEND_WEIGHT, detectIntent };
+module.exports = { rank, buildSigIndex, scoreFile, _queryWants, _isDataHolder, detectIntents, formatRankTable, formatRankJSON, DEFAULT_WEIGHTS, GRAPH_BOOST_AMOUNTS, CENTRALITY_BLEND_WEIGHT, detectIntent };

--- a/test/integration/java-extractor-caps.test.js
+++ b/test/integration/java-extractor-caps.test.js
@@ -1,0 +1,132 @@
+'use strict';
+
+/**
+ * Regression tests for the Java extractor's hard-coded caps (#551).
+ *
+ * Each acceptance criterion from the issue gets at least one test:
+ *  - class members are no longer capped at 8, and omissions are disclosed
+ *  - the per-file signature cap no longer shadows the configured maxSigsPerFile
+ *  - class bodies larger than 5,000 chars are no longer truncated
+ *
+ * Every assertion below fails against the pre-fix implementation.
+ */
+
+const assert = require('assert');
+const path = require('path');
+
+const ROOT = path.resolve(__dirname, '../..');
+const { extract } = require(path.join(ROOT, 'src', 'extractors', 'java'));
+
+let passed = 0;
+let failed = 0;
+
+function test(name, fn) {
+  try {
+    fn();
+    passed++;
+    console.log(`  PASS  ${name}`);
+  } catch (err) {
+    failed++;
+    console.log(`  FAIL  ${name}: ${err.message}`);
+  }
+}
+
+/**
+ * A POJO with `count` getter/setter pairs, mimicking a generated entity.
+ * `pad` grows each method body with real statements — not comments, which
+ * `extract()` strips before scanning and which therefore would not exercise
+ * the class-body scan cap at all.
+ */
+function entity(className, count, { pad = 0 } = {}) {
+  const body = [];
+  for (let i = 0; i < count; i++) {
+    body.push(`    public String getField${i}() {`);
+    if (pad) body.push(`        String pad${i} = "${'x'.repeat(pad)}";`);
+    body.push(`        return field${i};`);
+    body.push('    }');
+    body.push(`    public void setField${i}(String field${i}) {`);
+    body.push(`        this.field${i} = field${i};`);
+    body.push('    }');
+  }
+  return `package com.example;\n\npublic class ${className} {\n${body.join('\n')}\n}\n`;
+}
+
+const memberText = (sigs) => sigs.filter((s) => s.startsWith('  '));
+
+// ---------------------------------------------------------------------------
+// 1. Member cap
+// ---------------------------------------------------------------------------
+
+test('class with more than 8 methods yields more than 8 signatures', () => {
+  const sigs = extract(entity('Wide', 20));
+  const members = memberText(sigs);
+  assert.ok(members.length > 8, `expected >8 members, got ${members.length}`);
+});
+
+test('a method past the old 8-member cap is indexed with its own line anchor', () => {
+  const sigs = extract(entity('Wide', 20));
+  const late = sigs.find((s) => s.includes('setField19('));
+  assert.ok(late, 'setField19 must be indexed (it is the 40th member)');
+  assert.ok(/:\d+-\d+/.test(late), `member must carry a line anchor, got: ${late}`);
+});
+
+test('members beyond the ceiling are disclosed, not dropped silently', () => {
+  const sigs = extract(entity('Huge', 200));
+  const notice = sigs.find((s) => s.includes('more methods'));
+  assert.ok(notice, 'a "… +N more methods" marker must disclose the omission');
+  assert.ok(/\+\d+ more methods/.test(notice), `marker must state the count, got: ${notice}`);
+});
+
+// ---------------------------------------------------------------------------
+// 2. Per-file signature cap
+// ---------------------------------------------------------------------------
+
+test('per-file output is not capped at the old hard-coded 25', () => {
+  const sigs = extract(entity('Big', 40));
+  assert.ok(sigs.length > 25, `expected >25 signatures, got ${sigs.length}`);
+});
+
+test('per-file omissions are disclosed when the ceiling is reached', () => {
+  const sigs = extract(entity('Enormous', 400));
+  const notice = sigs.find((s) => s.includes('more signatures') || s.includes('more methods'));
+  assert.ok(notice, 'reaching the ceiling must append a disclosure marker');
+});
+
+// ---------------------------------------------------------------------------
+// 3. Class-body scan cap
+// ---------------------------------------------------------------------------
+
+test('a class body larger than 5,000 chars is not truncated', () => {
+  const src = entity('Fat', 30, { pad: 200 });
+  assert.ok(src.length > 5000, 'fixture must exceed the old 5,000-char cap');
+  const sigs = extract(src);
+  const classSig = sigs.find((s) => s.startsWith('class Fat'));
+  const [, end] = classSig.match(/:(\d+)-(\d+)/).slice(1).map(Number);
+  const lastLine = src.trimEnd().split('\n').length;
+  assert.ok(end >= lastLine - 1, `class span must reach the closing brace (${end} vs ${lastLine})`);
+});
+
+test('members declared past the 5,000-char mark are still extracted', () => {
+  const sigs = extract(entity('Fat', 30, { pad: 200 }));
+  assert.ok(sigs.find((s) => s.includes('setField29(')), 'trailing member must be indexed');
+});
+
+// ---------------------------------------------------------------------------
+// 4. Existing behaviour preserved
+// ---------------------------------------------------------------------------
+
+test('small classes are unchanged (no marker, anchors intact)', () => {
+  const sigs = extract(entity('Small', 2));
+  assert.ok(!sigs.some((s) => s.includes('more methods')), 'no marker for a small class');
+  assert.ok(sigs[0].startsWith('class Small'), 'class signature first');
+  assert.strictEqual(memberText(sigs).length, 4, 'all four members present');
+});
+
+test('non-Java / empty input still returns an empty array', () => {
+  assert.deepStrictEqual(extract(''), []);
+  assert.deepStrictEqual(extract(null), []);
+});
+
+console.log('');
+console.log(`${passed} passed, ${failed} failed`);
+if (failed > 0) process.exit(1);

--- a/test/integration/retrieval.test.js
+++ b/test/integration/retrieval.test.js
@@ -451,6 +451,67 @@ test('v6.6 formatRankJSON: includes intent and signals', () => {
 // ---------------------------------------------------------------------------
 // Results
 // ---------------------------------------------------------------------------
+
+// ---------------------------------------------------------------------------
+// Data-holder penalty — generated entities must not outrank logic (#552 follow-up)
+// ---------------------------------------------------------------------------
+
+const { _isDataHolder } = require(path.join(ROOT, 'src', 'retrieval', 'ranker'));
+
+const ENTITY = ['class OmsOrder  :8-547'].concat(
+  ['Id', 'MemberId', 'Note', 'Status', 'PayType', 'CouponId', 'OrderSn'].flatMap((f) => [
+    `  get${f}() → String  :10-10`,
+    `  set${f}(String ${f.toLowerCase()}) → void  :14-14`,
+  ]));
+const SERVICE = [
+  'class OmsPortalOrderServiceImpl  :33-145',
+  '  generateOrder(OrderParam orderParam) → Map<String, Object>  :94-94',
+  '  generateConfirmOrder(List<Long> cartIds) → ConfirmOrderResult  :70-70',
+  '  paySuccess(Long orderId, Integer payType) → Map  :120-120',
+  '  cancelOrder(Long orderId) → void  :130-130',
+  '  sendDelayMessageCancelOrder(Long orderId) → void  :138-138',
+  '  cancelTimeOutOrder() → CommonResult  :142-142',
+];
+
+test('data holder: an accessor-only entity is detected', () => {
+  assert.strictEqual(_isDataHolder(ENTITY), true);
+});
+
+test('data holder: a service with real methods is not', () => {
+  assert.strictEqual(_isDataHolder(SERVICE), false);
+});
+
+test('data holder: a small class is not judged a data holder', () => {
+  assert.strictEqual(_isDataHolder(['class Tiny  :1-9', '  getId() → Long  :3-3', '  setId(Long id) → void  :5-5']), false);
+});
+
+test('data holder: a generated entity no longer outranks the service that shares its terms', () => {
+  const index = new Map([
+    ['mall-mbg/src/main/java/com/macro/mall/model/OmsOrder.java', ENTITY],
+    ['mall-portal/src/main/java/com/macro/mall/portal/service/impl/OmsPortalOrderServiceImpl.java', SERVICE],
+  ]);
+  const results = rank('order note', index, { topK: 10 });
+  const svc = results.findIndex((r) => r.file.includes('OmsPortalOrderServiceImpl'));
+  const ent = results.findIndex((r) => r.file.includes('model/OmsOrder.java'));
+  assert.ok(svc !== -1 && ent !== -1, 'both files should be ranked');
+  assert.ok(svc < ent, `the service must outrank the entity (service ${svc}, entity ${ent})`);
+});
+
+test('data holder: the penalty is not applied when the query asks for the entity', () => {
+  const index = new Map([['mall-mbg/src/main/java/com/macro/mall/model/OmsOrder.java', ENTITY]]);
+  const penalised = rank('order note', index, { topK: 5 })[0].signals.penalty;
+  const wanted = rank('order note entity getter', index, { topK: 5 })[0].signals.penalty;
+  assert.ok(penalised < 1.0, 'a plain query should demote the entity');
+  assert.strictEqual(wanted, 1.0, 'asking for an entity/getter must lift the penalty');
+});
+
+test('data holder: the entity is still retrievable by its own symbol', () => {
+  const index = new Map([['mall-mbg/src/main/java/com/macro/mall/model/OmsOrder.java', ENTITY]]);
+  const results = rank('setNote', index, { topK: 5 });
+  assert.ok(results.length > 0 && results[0].score > 0,
+    'demoting must not make the symbol unfindable — that was the bug #552 fixed');
+});
+
 console.log('');
 console.log(`${passed} passed, ${failed} failed`);
 

--- a/version.json
+++ b/version.json
@@ -5,7 +5,7 @@
   "languages": 33,
   "extractors": 43,
   "mcp_tools": 21,
-  "tests": 139,
+  "tests": 140,
   "metrics": {
     "hit_at_5": 0.811,
     "baseline_hit_at_5": 0.136,


### PR DESCRIPTION
Closes #551.

## Problem

Three hard-coded caps in `src/extractors/java.js` made the index unusable on real Java codebases. None could be worked around with config.

| Cap | Effect on `macrozheng/mall` (524 Java files) |
|---|---|
| `members.slice(0, 8)` | **10,415 of 12,250 public methods hidden (85%)** — silently, with no `… +N more` marker |
| `sigs.slice(0, 25)` | shadowed the configured `maxSigsPerFile` |
| 5,000-char class-body cap | `OmsOrder.java` indexed as `:8-235`; the class ends at line **547**. 103 of 524 files (20%) exceed it |

The practical failure: `search_signatures setNote` returned *"No signatures found"* though the symbol exists, so agents fell back to bulk-reading whole files (`get_lines OmsOrder.java 1-235`) instead of jumping to a line anchor.

## Change

Caps become named constants sitting **above** the configured budget, so `maxSigsPerFile` genuinely governs the output, and both ceilings disclose omissions via the shared `capWithNotice` / `capMembersWithNotice` helpers — the same path JS/TS already use.

The disclosure marker carries no offsets, so it is anchored at the class body (matching the JS extractor's behaviour).

## Verification

Against `macrozheng/mall` with the rebuilt bundle:

```
Symbols found : 3,768 → 8,468        (+125%)
Coverage      : A (99%) — 519 of 524 source files
class OmsOrder  :8-547               (was :8-235)
setNote(String note) → void  :425-425   (was absent)
```

## Tests

`test/integration/java-extractor-caps.test.js` — 9 tests. **7 fail against the pre-fix implementation** (verified by stashing the change); the 2 that pass both ways are the deliberate "existing behaviour preserved" guards.

Full suite: **134 passed, 0 failed**. Bundle regenerated (`npm run build:bundle`) so the published single-file CLI carries the fix; `version.json` test count synced 139 → 140.

Supply-chain gate: local audit PASS — no shell spawns, no install scripts, `main` exports an API, no fingerprinting.

## Not addressed here

The same `sigs.slice(0, 25)` pattern exists in **go, rust, kotlin, swift, php, scala, csharp, and dart**, and `extractBlock` caps range 2,000–5,000 chars across them. Worth a follow-up issue — this PR stays scoped to Java.

Issue #551 also records three config-level Java problems not fixed here: `maxDepth: 6` missing Maven trees, `maxTokens` not pinning without `autoMaxTokens: false`, and the call graph yielding zero edges on Java.