### PR TITLE
feat(skills): invokable sigmap-task prompt skill that works without MCP

### DIFF
--- a/gen-context.js
+++ b/gen-context.js
@@ -18738,6 +18738,24 @@ __factories["./src/skills/skills"] = function(module, exports) {
         '6. **Watch the budget.** Check the `get_budget` MCP tool or `sigmap budget` (estimates from SigMap\'s local ledger — no LLM calls). Near the budget: summarize-then-drop older context instead of accumulating, and prefer terse output.',
       ].join('\n'),
     },
+    'sigmap-task': {
+      title: 'SigMap task loop',
+      kind: 'prompt',
+      description: 'Do a coding task grounded in SigMap: look up before reading, edit by line anchor, verify before reporting.',
+      argumentHint: 'the change you want, in plain words',
+      body: [
+        'Work through these steps **in order**. Do not open any file before step 2.',
+        'Every command runs from the integrated terminal — do not ask the user to run them for you.',
+        '',
+        '1. **Look up, do not search.** `npx sigmap ask "<the task>"` — this writes `.context/query-context.md`.',
+        '2. **Read the map.** `cat .context/query-context.md`. It ranks the relevant files and lists their signatures with `:start-end` line anchors — a few hundred tokens where the same files read whole are tens of thousands. Say which files it surfaced before continuing. If nothing relevant appears, re-run step 1 with different wording; fall back to search only after two attempts, and say so.',
+        '3. **Open only the anchored ranges.** A signature ending `:425-425` means read line 425, not the whole file. Never read a file in full when you hold an anchor for it.',
+        '4. **Make the change.** Follow the conventions visible in the signatures — same layering, same response wrapper, same annotation style. Add no dependencies.',
+        '5. **Verify before reporting.** Write what you changed to `.sigmap-notes.md`, naming every file by its **full repository-relative path** (a bare filename is reported as fake), then run `npx sigmap verify-ai-output .sigmap-notes.md`. It checks every name against the real index, offline, with no model call. Fix anything it flags and re-run before you reply.',
+        '6. **Refresh the map.** `npx sigmap` — your edits made it stale.',
+        '7. **Report.** The files you changed, the ranges you actually read, the step-1 token count, and the step-5 verify result. Say so if you fell back to searching or if verify flagged something.',
+      ].join('\n'),
+    },
     'sigmap-config-optimizer': {
       title: 'SigMap config optimizer',
       description: 'Playbook for getting a correct SigMap config on any repo: detect with sigmap tune, review the per-change reasons, apply, validate.',
@@ -18762,7 +18780,9 @@ __factories["./src/skills/skills"] = function(module, exports) {
     windsurf: { label: 'Windsurf',       parent: ['.windsurf'],
                 target: (cwd, skill) => path.join(cwd, '.windsurf', 'rules', `${skill}.md`) },
     copilot:  { label: 'GitHub Copilot', parent: ['.github'],
-                target: (cwd, skill) => path.join(cwd, '.github', 'instructions', `${skill}.instructions.md`) },
+                target: (cwd, skill) => (SKILLS[skill] && SKILLS[skill].kind === 'prompt'
+                  ? path.join(cwd, '.github', 'prompts', `${skill}.prompt.md`)
+                  : path.join(cwd, '.github', 'instructions', `${skill}.instructions.md`)) },
     codex:    { label: 'Codex CLI (AGENTS.md)', parent: ['AGENTS.md'],
                 target: (cwd) => path.join(cwd, 'AGENTS.md'), inject: true },
   };
@@ -18783,6 +18803,10 @@ __factories["./src/skills/skills"] = function(module, exports) {
       return `---\ndescription: ${skill.description}\nalwaysApply: false\n---\n\n${body}`;
     }
     if (client === 'copilot') {
+      if (skill.kind === 'prompt') {
+        return `---\nname: ${skillName}\nagent: 'agent'\ndescription: ${skill.description}\n`
+          + `argument-hint: ${skill.argumentHint}\n---\n\n${body}`;
+      }
       return `---\napplyTo: "**"\n---\n\n${body}`;
     }
     return body; // windsurf: plain markdown

--- a/src/skills/skills.js
+++ b/src/skills/skills.js
@@ -34,6 +34,24 @@ const SKILLS = {
       '6. **Watch the budget.** Check the `get_budget` MCP tool or `sigmap budget` (estimates from SigMap\'s local ledger — no LLM calls). Near the budget: summarize-then-drop older context instead of accumulating, and prefer terse output.',
     ].join('\n'),
   },
+  'sigmap-task': {
+    title: 'SigMap task loop',
+    kind: 'prompt',
+    description: 'Do a coding task grounded in SigMap: look up before reading, edit by line anchor, verify before reporting.',
+    argumentHint: 'the change you want, in plain words',
+    body: [
+      'Work through these steps **in order**. Do not open any file before step 2.',
+      'Every command runs from the integrated terminal — do not ask the user to run them for you.',
+      '',
+      '1. **Look up, do not search.** `npx sigmap ask "<the task>"` — this writes `.context/query-context.md`.',
+      '2. **Read the map.** `cat .context/query-context.md`. It ranks the relevant files and lists their signatures with `:start-end` line anchors — a few hundred tokens where the same files read whole are tens of thousands. Say which files it surfaced before continuing. If nothing relevant appears, re-run step 1 with different wording; fall back to search only after two attempts, and say so.',
+      '3. **Open only the anchored ranges.** A signature ending `:425-425` means read line 425, not the whole file. Never read a file in full when you hold an anchor for it.',
+      '4. **Make the change.** Follow the conventions visible in the signatures — same layering, same response wrapper, same annotation style. Add no dependencies.',
+      '5. **Verify before reporting.** Write what you changed to `.sigmap-notes.md`, naming every file by its **full repository-relative path** (a bare filename is reported as fake), then run `npx sigmap verify-ai-output .sigmap-notes.md`. It checks every name against the real index, offline, with no model call. Fix anything it flags and re-run before you reply.',
+      '6. **Refresh the map.** `npx sigmap` — your edits made it stale.',
+      '7. **Report.** The files you changed, the ranges you actually read, the step-1 token count, and the step-5 verify result. Say so if you fell back to searching or if verify flagged something.',
+    ].join('\n'),
+  },
   'sigmap-config-optimizer': {
     title: 'SigMap config optimizer',
     description: 'Playbook for getting a correct SigMap config on any repo: detect with sigmap tune, review the per-change reasons, apply, validate.',
@@ -58,7 +76,9 @@ const SKILL_CLIENTS = {
   windsurf: { label: 'Windsurf',       parent: ['.windsurf'],
               target: (cwd, skill) => path.join(cwd, '.windsurf', 'rules', `${skill}.md`) },
   copilot:  { label: 'GitHub Copilot', parent: ['.github'],
-              target: (cwd, skill) => path.join(cwd, '.github', 'instructions', `${skill}.instructions.md`) },
+              target: (cwd, skill) => (SKILLS[skill] && SKILLS[skill].kind === 'prompt'
+                ? path.join(cwd, '.github', 'prompts', `${skill}.prompt.md`)
+                : path.join(cwd, '.github', 'instructions', `${skill}.instructions.md`)) },
   codex:    { label: 'Codex CLI (AGENTS.md)', parent: ['AGENTS.md'],
               target: (cwd) => path.join(cwd, 'AGENTS.md'), inject: true },
 };
@@ -79,6 +99,10 @@ function renderSkill(client, skillName, version) {
     return `---\ndescription: ${skill.description}\nalwaysApply: false\n---\n\n${body}`;
   }
   if (client === 'copilot') {
+    if (skill.kind === 'prompt') {
+      return `---\nname: ${skillName}\nagent: 'agent'\ndescription: ${skill.description}\n`
+        + `argument-hint: ${skill.argumentHint}\n---\n\n${body}`;
+    }
     return `---\napplyTo: "**"\n---\n\n${body}`;
   }
   return body; // windsurf: plain markdown

--- a/test/integration/skills.test.js
+++ b/test/integration/skills.test.js
@@ -151,5 +151,66 @@ test('CLI: skills list --json, install --client creates, --help documents skills
   rm(dir);
 });
 
+
+// ---------------------------------------------------------------------------
+// sigmap-task prompt skill (#553) — invokable, CLI-only, MCP-free
+// ---------------------------------------------------------------------------
+
+test('sigmap-task is a prompt-kind skill', () => {
+  assert.ok(SKILLS['sigmap-task'], 'sigmap-task skill must exist');
+  assert.strictEqual(SKILLS['sigmap-task'].kind, 'prompt');
+});
+
+test('copilot installs sigmap-task to .github/prompts as a .prompt.md', () => {
+  const dir = tmp({ dirs: ['.github'] });
+  const r = installSkills('copilot', { cwd: dir, version: '9.9.9' });
+  const entry = r.results.find((x) => x.skill === 'sigmap-task');
+  assert.ok(entry, 'sigmap-task must be installed');
+  assert.ok(entry.path.endsWith(path.join('.github', 'prompts', 'sigmap-task.prompt.md')),
+    `wrong target: ${entry.path}`);
+  rm(dir);
+});
+
+test('copilot still installs playbooks to .github/instructions', () => {
+  const dir = tmp({ dirs: ['.github'] });
+  const r = installSkills('copilot', { cwd: dir, version: '9.9.9' });
+  const entry = r.results.find((x) => x.skill === 'sigmap-usage-maximizer');
+  assert.ok(entry.path.includes(path.join('.github', 'instructions')), `wrong target: ${entry.path}`);
+  rm(dir);
+});
+
+test('the prompt file carries frontmatter that makes /sigmap-task invokable', () => {
+  const out = renderSkill('copilot', 'sigmap-task', '9.9.9');
+  assert.ok(out.startsWith('---\n'), 'must open with frontmatter');
+  const fm = out.split('---')[1];
+  assert.ok(/name:\s*sigmap-task/.test(fm), 'needs a name for /invocation');
+  assert.ok(/agent:\s*'agent'/.test(fm), 'must run in agent mode to execute commands');
+  assert.ok(/argument-hint:/.test(fm), 'needs an argument hint');
+  assert.ok(!/applyTo/.test(fm), 'prompt files must not use the instructions frontmatter');
+});
+
+test('the task loop never instructs the agent to use MCP tools', () => {
+  const body = SKILLS['sigmap-task'].body;
+  for (const mcpOnly of ['query_context', 'get_lines', 'verify_suggestion', 'squeeze_output', 'get_budget']) {
+    assert.ok(!body.includes(mcpOnly), `sigmap-task must stay CLI-only, found: ${mcpOnly}`);
+  }
+  assert.ok(body.includes('npx sigmap ask'), 'must lead with the CLI lookup');
+  assert.ok(body.includes('verify-ai-output'), 'must verify via the CLI');
+});
+
+test('the task loop tells the agent to use full repo-relative paths when verifying', () => {
+  assert.ok(/repository-relative path/.test(SKILLS['sigmap-task'].body),
+    'bare filenames are reported as fake files — the loop must say so');
+});
+
+test('sigmap-task installs for claude as a normal skill file', () => {
+  const dir = tmp({ dirs: ['.claude'] });
+  const r = installSkills('claude', { cwd: dir, version: '9.9.9' });
+  const entry = r.results.find((x) => x.skill === 'sigmap-task');
+  assert.ok(entry.path.endsWith(path.join('.claude', 'skills', 'sigmap-task', 'SKILL.md')),
+    `wrong target: ${entry.path}`);
+  rm(dir);
+});
+
 console.log(`\n  skills: ${pass} passed, ${fail} failed`);
 process.exit(fail ? 1 : 0);


### PR DESCRIPTION
Closes #553.

## Problem

`sigmap skills install` shipped only always-on playbooks, and **five of the six steps** in `sigmap-usage-maximizer` instruct the agent to call MCP tools (`get_lines`, `verify_suggestion`, `squeeze_output`, `create_checkpoint`, `get_budget`).

Where MCP is disabled — common in corporate environments, and the norm for GitHub Copilot — the agent loads a playbook naming tools it cannot call, and falls back to bulk-reading files. That is precisely the behaviour SigMap exists to prevent.

Step 2 ("read ranges, not files") is the one that matters most, and it had no CLI alternative offered at all.

## Change

Adds `sigmap-task`, a **prompt-kind** skill — an ordered, CLI-only loop the user invokes deliberately rather than hoping an always-on file is honoured:

| Step | Command |
|---|---|
| 1. Look up, don't search | `npx sigmap ask "<task>"` |
| 2. Read the map | `cat .context/query-context.md`, state what it surfaced |
| 3. Open only anchored ranges | `:425-425` means line 425, not the 547-line file |
| 4. Make the change | follow conventions visible in the signatures |
| 5. Verify | `npx sigmap verify-ai-output` — fix and re-run if flagged |
| 6. Refresh | `npx sigmap` — edits made the map stale |
| 7. Report | ranges read, token count, verify result |

**Routing.** For Copilot it installs to `.github/prompts/sigmap-task.prompt.md` with prompt frontmatter (`name` / `agent: 'agent'` / `description` / `argument-hint`), so `/sigmap-task` invokes it in agent mode where it can run commands. Existing playbooks keep going to `.github/instructions/`. Other clients install it through their normal skill path.

**Step 5 wording matters.** `verify-ai-output` reports a bare filename as a fake file, so the loop requires full repository-relative paths. Without that, a test run had the agent chasing a problem that did not exist.

## Verified end to end

Against `macrozheng/mall` (524 Java files) with **GitHub Copilot and MCP off**. Copilot ran the loop itself — no pasting:

```
13:01:09  ask       baseline= 12,559  actual=967  saved= 92.3%
13:01:26  ask       baseline= 11,986  actual=906  saved= 92.4%
13:01:48  ask       baseline=  3,082  actual=639  saved= 79.3%
13:02:48  generate  (map refreshed — step 6)
```

It called `ask` three times, refining the query exactly as step 2 instructs, then refreshed the map. **2,512 tokens of lookups against 27,627 tokens of equivalent file reading**, landing the same 2-file, 3-line patch that Claude Code produced, with 2/2 behavioural asserts and edit precision 1.00.

## Tests

7 new cases in `test/integration/skills.test.js` covering: prompt-kind routing to `.github/prompts`, playbooks still routing to `.github/instructions`, invokable frontmatter (and absence of `applyTo`), a guard that the loop **never** names an MCP-only tool, the repo-relative-path requirement, and the Claude install path.

Full suite: **133 passed, 0 failed**. Bundle regenerated.