### PR TITLE
fix(mcp): write VS Code's servers key so Copilot can see the server

### DIFF
--- a/gen-context.js
+++ b/gen-context.js
@@ -15250,6 +15250,7 @@ __factories["./src/mcp/install"] = function(module, exports) {
 
   // Config shapes the supported clients use.
   //  - 'json'  → { mcpServers: { sigmap: { command, args } } }
+  //  - 'vscode'→ { servers: { sigmap: { type: 'stdio', command, args } } }
   //  - 'zed'   → { context_servers: { sigmap: { command: { path, args } } } }
   //  - 'yaml'  → Codex CLI ~/.codex/config.yaml (mcpServers block, appended)
   const CLIENTS = {
@@ -15258,7 +15259,7 @@ __factories["./src/mcp/install"] = function(module, exports) {
     windsurf: { label: 'Windsurf',     format: 'json', scope: 'both',
                 project: ['.windsurf', 'mcp.json'],
                 global:  ['.codeium', 'windsurf', 'mcp_config.json'] },
-    vscode:   { label: 'VS Code',      format: 'json', scope: 'project', project: ['.vscode', 'mcp.json'] },
+    vscode:   { label: 'VS Code',      format: 'vscode', scope: 'project', project: ['.vscode', 'mcp.json'] },
     opencode: { label: 'OpenCode',     format: 'json', scope: 'both',
                 project: ['opencode.json'],
                 global:  ['.config', 'opencode', 'config.json'] },
@@ -15313,6 +15314,31 @@ __factories["./src/mcp/install"] = function(module, exports) {
     return 'installed';
   }
 
+  /**
+   * Install into VS Code's `.vscode/mcp.json`, which keys servers under `servers`
+   * (not `mcpServers`) and expects an explicit transport `type`. A config written
+   * by an older SigMap under `mcpServers` is migrated rather than left in place,
+   * so re-running repairs it instead of leaving two entries VS Code cannot read.
+   */
+  function _installVscode(filePath, scriptPath) {
+    let settings = {};
+    if (fs.existsSync(filePath)) {
+      try { settings = JSON.parse(fs.readFileSync(filePath, 'utf8')) || {}; }
+      catch (_) { settings = {}; }
+    }
+    const stale = settings.mcpServers && settings.mcpServers.sigmap;
+    if (stale) {
+      delete settings.mcpServers.sigmap;
+      if (Object.keys(settings.mcpServers).length === 0) delete settings.mcpServers;
+    }
+    if (!settings.servers) settings.servers = {};
+    if (settings.servers.sigmap && !stale) return 'already';
+    settings.servers.sigmap = { type: 'stdio', command: 'node', args: serverArgs(scriptPath) };
+    fs.mkdirSync(path.dirname(filePath), { recursive: true });
+    fs.writeFileSync(filePath, JSON.stringify(settings, null, 2) + '\n');
+    return stale ? 'updated' : 'installed';
+  }
+
   /** Install into Zed's `context_servers` config (create file/dir if absent). */
   function _installZed(filePath, scriptPath) {
     let settings = {};
@@ -15365,7 +15391,8 @@ __factories["./src/mcp/install"] = function(module, exports) {
     const filePath   = resolveTarget(spec, cwd, home, opts.global);
 
     let status;
-    if (spec.format === 'zed')       status = _installZed(filePath, scriptPath);
+    if (spec.format === 'vscode')    status = _installVscode(filePath, scriptPath);
+    else if (spec.format === 'zed')  status = _installZed(filePath, scriptPath);
     else if (spec.format === 'yaml') status = _installYaml(filePath, scriptPath);
     else                             status = _installJson(filePath, scriptPath);
 

--- a/src/mcp/install.js
+++ b/src/mcp/install.js
@@ -17,6 +17,7 @@ const os   = require('os');
 
 // Config shapes the supported clients use.
 //  - 'json'  → { mcpServers: { sigmap: { command, args } } }
+//  - 'vscode'→ { servers: { sigmap: { type: 'stdio', command, args } } }
 //  - 'zed'   → { context_servers: { sigmap: { command: { path, args } } } }
 //  - 'yaml'  → Codex CLI ~/.codex/config.yaml (mcpServers block, appended)
 const CLIENTS = {
@@ -25,7 +26,7 @@ const CLIENTS = {
   windsurf: { label: 'Windsurf',     format: 'json', scope: 'both',
               project: ['.windsurf', 'mcp.json'],
               global:  ['.codeium', 'windsurf', 'mcp_config.json'] },
-  vscode:   { label: 'VS Code',      format: 'json', scope: 'project', project: ['.vscode', 'mcp.json'] },
+  vscode:   { label: 'VS Code',      format: 'vscode', scope: 'project', project: ['.vscode', 'mcp.json'] },
   opencode: { label: 'OpenCode',     format: 'json', scope: 'both',
               project: ['opencode.json'],
               global:  ['.config', 'opencode', 'config.json'] },
@@ -80,6 +81,31 @@ function _installJson(filePath, scriptPath) {
   return 'installed';
 }
 
+/**
+ * Install into VS Code's `.vscode/mcp.json`, which keys servers under `servers`
+ * (not `mcpServers`) and expects an explicit transport `type`. A config written
+ * by an older SigMap under `mcpServers` is migrated rather than left in place,
+ * so re-running repairs it instead of leaving two entries VS Code cannot read.
+ */
+function _installVscode(filePath, scriptPath) {
+  let settings = {};
+  if (fs.existsSync(filePath)) {
+    try { settings = JSON.parse(fs.readFileSync(filePath, 'utf8')) || {}; }
+    catch (_) { settings = {}; }
+  }
+  const stale = settings.mcpServers && settings.mcpServers.sigmap;
+  if (stale) {
+    delete settings.mcpServers.sigmap;
+    if (Object.keys(settings.mcpServers).length === 0) delete settings.mcpServers;
+  }
+  if (!settings.servers) settings.servers = {};
+  if (settings.servers.sigmap && !stale) return 'already';
+  settings.servers.sigmap = { type: 'stdio', command: 'node', args: serverArgs(scriptPath) };
+  fs.mkdirSync(path.dirname(filePath), { recursive: true });
+  fs.writeFileSync(filePath, JSON.stringify(settings, null, 2) + '\n');
+  return stale ? 'updated' : 'installed';
+}
+
 /** Install into Zed's `context_servers` config (create file/dir if absent). */
 function _installZed(filePath, scriptPath) {
   let settings = {};
@@ -132,7 +158,8 @@ function installClient(client, opts = {}) {
   const filePath   = resolveTarget(spec, cwd, home, opts.global);
 
   let status;
-  if (spec.format === 'zed')       status = _installZed(filePath, scriptPath);
+  if (spec.format === 'vscode')    status = _installVscode(filePath, scriptPath);
+  else if (spec.format === 'zed')  status = _installZed(filePath, scriptPath);
   else if (spec.format === 'yaml') status = _installYaml(filePath, scriptPath);
   else                             status = _installJson(filePath, scriptPath);
 

--- a/test/integration/mcp/install.test.js
+++ b/test/integration/mcp/install.test.js
@@ -214,6 +214,74 @@ test('mcp install with no client name exits non-zero with usage', () => {
   }
 });
 
+
+// ── VS Code uses `servers`, not `mcpServers` (#556) ───────────────────────────
+
+const { installClient: _install } = require(path.resolve(__dirname, '../../../src/mcp/install.js'));
+const readJson = (f) => JSON.parse(fs.readFileSync(f, 'utf8'));
+
+test('vscode: writes a top-level servers key, not mcpServers', () => {
+  const dir = makeTmpDir();
+  const r = _install('vscode', { cwd: dir, scriptPath: '/x/gen-context.js' });
+  assert.strictEqual(r.status, 'installed');
+  const cfg = readJson(r.path);
+  assert.ok(cfg.servers, 'VS Code reads `servers` — it ignores `mcpServers`');
+  assert.ok(!cfg.mcpServers, 'must not write the generic mcpServers shape');
+  assert.ok(cfg.servers.sigmap, 'sigmap entry missing');
+});
+
+test('vscode: the entry declares the stdio transport', () => {
+  const dir = makeTmpDir();
+  const r = _install('vscode', { cwd: dir, scriptPath: '/x/gen-context.js' });
+  const e = readJson(r.path).servers.sigmap;
+  assert.strictEqual(e.type, 'stdio');
+  assert.strictEqual(e.command, 'node');
+  assert.deepStrictEqual(e.args, [path.resolve('/x/gen-context.js'), '--mcp']);
+});
+
+test('vscode: re-running is idempotent', () => {
+  const dir = makeTmpDir();
+  _install('vscode', { cwd: dir, scriptPath: '/x/gen-context.js' });
+  const again = _install('vscode', { cwd: dir, scriptPath: '/x/gen-context.js' });
+  assert.strictEqual(again.status, 'already');
+});
+
+test('vscode: a legacy mcpServers.sigmap config is migrated to servers', () => {
+  const dir = makeTmpDir();
+  fs.mkdirSync(path.join(dir, '.vscode'), { recursive: true });
+  fs.writeFileSync(path.join(dir, '.vscode', 'mcp.json'), JSON.stringify({
+    servers: { playwright: { command: 'npx', args: ['-y', 'pw'] } },
+    mcpServers: { sigmap: { command: 'node', args: ['/old/gen-context.js', '--mcp'] } },
+  }, null, 2));
+  const r = _install('vscode', { cwd: dir, scriptPath: '/x/gen-context.js' });
+  assert.strictEqual(r.status, 'updated');
+  const cfg = readJson(r.path);
+  assert.ok(cfg.servers.sigmap, 'sigmap must move under servers');
+  assert.ok(!cfg.mcpServers, 'the stale mcpServers block must be removed');
+  assert.ok(cfg.servers.playwright, 'unrelated servers must be preserved');
+});
+
+test('vscode: unrelated keys in the file survive', () => {
+  const dir = makeTmpDir();
+  fs.mkdirSync(path.join(dir, '.vscode'), { recursive: true });
+  fs.writeFileSync(path.join(dir, '.vscode', 'mcp.json'),
+    JSON.stringify({ inputs: [{ id: 'token', type: 'promptString' }] }, null, 2));
+  const r = _install('vscode', { cwd: dir, scriptPath: '/x/gen-context.js' });
+  const cfg = readJson(r.path);
+  assert.ok(Array.isArray(cfg.inputs) && cfg.inputs.length === 1, 'inputs must be preserved');
+  assert.ok(cfg.servers.sigmap);
+});
+
+test('other json clients still write mcpServers', () => {
+  for (const client of ['claude', 'cursor', 'mcp']) {
+    const dir = makeTmpDir();
+    const r = _install(client, { cwd: dir, scriptPath: '/x/gen-context.js' });
+    const cfg = readJson(r.path);
+    assert.ok(cfg.mcpServers && cfg.mcpServers.sigmap, `${client} must keep the mcpServers shape`);
+    assert.ok(!cfg.servers, `${client} must not switch to the VS Code shape`);
+  }
+});
+
 // ── Summary ───────────────────────────────────────────────────────────────────
 console.log(`\n${passed} passed, ${failed} failed\n`);
 if (failed > 0) process.exit(1);


### PR DESCRIPTION
Closes #556.

## Problem

`sigmap mcp install vscode` wrote `.vscode/mcp.json` using the generic `mcpServers` shape. VS Code reads a top-level **`servers`** key. The file was written, the command reported success, and VS Code silently ignored it — so GitHub Copilot never saw the SigMap MCP server, with no error to explain why.

Zed already had a dedicated writer for its `context_servers` shape ([install.js](src/mcp/install.js)); VS Code fell through to the shared JSON writer instead.

| | Written before | VS Code expects |
|---|---|---|
| top-level key | `mcpServers` | `servers` |
| transport | *(absent)* | `type: "stdio"` |

## Change

New `vscode` format:

```json
{ "servers": { "sigmap": { "type": "stdio", "command": "node", "args": ["…", "--mcp"] } } }
```

**Migration.** A config previously written under `mcpServers.sigmap` is moved to `servers` and the stale block removed, so re-running the command *repairs* a broken setup rather than leaving two entries VS Code cannot read. It reports `updated` in that case.

Unrelated servers and other top-level keys (e.g. VS Code's `inputs`) are preserved. Every other client's shape is untouched.

## Verification

Confirmed against the [VS Code MCP documentation](https://code.visualstudio.com/docs/copilot/customization/mcp-servers), which uses `servers` for both workspace and user-profile `mcp.json` and documents no `mcpServers` fallback.

Reproduced on macOS with VS Code + GitHub Copilot: with the previously generated file, no SigMap tools appear; with the new shape all 21 are available.

## Tests

6 new cases in `test/integration/mcp/install.test.js`:

- writes `servers`, never `mcpServers`
- entry declares `type: "stdio"` with the right command and args
- re-running is idempotent
- a legacy `mcpServers.sigmap` config migrates, preserving unrelated servers
- unrelated top-level keys survive
- **guard**: claude / cursor / portable still write `mcpServers` and must not switch shape

**4 of the 6 fail against the pre-fix implementation** (verified by stashing the change). The 2 that pass both ways are the idempotency check and the don't-break-other-clients guard — neither should change behaviour.

Full suite: **133 passed, 0 failed**. Bundle regenerated.

Supply-chain gate: local audit PASS — no shell spawns, no install scripts, `main` exports an API, no fingerprinting, tarball unchanged at 624KB / 171 files.