### PR TITLE
fix(graph): resolve srcDirs from config and lift the walk depth cap

### DIFF
--- a/gen-context.js
+++ b/gen-context.js
@@ -11752,24 +11752,60 @@ __factories["./src/graph/builder"] = function(module, exports) {
     return { forward, reverse };
   }
 
+  // Directory names assumed when neither the caller nor the project config says
+  // otherwise. A Maven/Gradle module (`mall-portal/`, `service-api/`) matches none
+  // of them, which is why the config is consulted first.
+  const DEFAULT_SRC_DIRS = ['src', 'app', 'lib', 'R', 'inst'];
+
+  // Walk depth measured from EACH srcDir root, not from cwd — so this is not the
+  // same quantity as the extractor's cwd-relative `maxDepth` and must not be read
+  // from it. A standard Maven tree reaches `src/main/java/<group>/<artifact>/…`
+  // nine directories below its module root, so the previous ceiling of 8 silently
+  // dropped the deepest packages (on macrozheng/mall: every `service/impl/` class).
+  const DEFAULT_WALK_DEPTH = 12;
+
+  /**
+   * Source directories declared in the project's own config, or null when there
+   * is no readable config. Read directly rather than through `loadConfig`, which
+   * can fetch `extends` over the network and spawn a child process — neither is
+   * acceptable inside a graph build.
+   */
+  function _configuredSrcDirs(cwd) {
+    try {
+      const raw = fs.readFileSync(path.join(cwd, 'gen-context.config.json'), 'utf8');
+      const cfg = JSON.parse(raw);
+      if (Array.isArray(cfg.srcDirs) && cfg.srcDirs.length > 0) return cfg.srcDirs;
+    } catch (_) { /* absent or unparsable — fall back to the defaults */ }
+    return null;
+  }
+
   /**
    * Build a dependency graph scoped to a single cwd by walking all JS/TS/Py/Go
    * files under srcDirs. Useful for the MCP tool handler.
+   *
+   * srcDirs resolution order: explicit `opts.srcDirs` → `gen-context.config.json`
+   * → DEFAULT_SRC_DIRS. Without the config step the graph is empty on any repo
+   * whose sources do not sit under a conventionally-named directory.
    *
    * @param {string} cwd
    * @param {object} [opts]
    * @param {string[]} [opts.srcDirs]
    * @param {string[]} [opts.exclude]
+   * @param {number}   [opts.maxDepth] - walk depth from each srcDir root
    * @returns {{ forward: Map<string,string[]>, reverse: Map<string,string[]> }}
    */
   function buildFromCwd(cwd, opts) {
     // R-package layouts use `R/` and `inst/`; Shiny apps put helpers in `R/`.
     // The existence check below makes these no-ops in non-R projects.
-    const { srcDirs = ['src', 'app', 'lib', 'R', 'inst'], exclude = ['node_modules', '.git', 'dist', 'build'] } = opts || {};
+    const {
+      srcDirs = _configuredSrcDirs(cwd) || DEFAULT_SRC_DIRS,
+      exclude = ['node_modules', '.git', 'dist', 'build'],
+      maxDepth = DEFAULT_WALK_DEPTH,
+    } = opts || {};
     const excludeSet = new Set(exclude);
 
     function walkDir(dir, depth) {
-      if (depth > 8) return [];
+      if (depth > maxDepth) return [];
       let entries;
       try { entries = fs.readdirSync(dir, { withFileTypes: true }); } catch (_) { return []; }
       const out = [];
@@ -11818,7 +11854,7 @@ __factories["./src/graph/builder"] = function(module, exports) {
     return build(files, cwd, ctx);
   }
 
-  module.exports = { build, buildFromCwd, extractFileDeps, normalizePath, loadAliasMap, resolveAlias };
+  module.exports = { build, buildFromCwd, extractFileDeps, normalizePath, loadAliasMap, resolveAlias, _configuredSrcDirs, DEFAULT_SRC_DIRS, DEFAULT_WALK_DEPTH };
   
 };
 

--- a/src/graph/builder.js
+++ b/src/graph/builder.js
@@ -434,24 +434,60 @@ function build(files, cwd, ctx) {
   return { forward, reverse };
 }
 
+// Directory names assumed when neither the caller nor the project config says
+// otherwise. A Maven/Gradle module (`mall-portal/`, `service-api/`) matches none
+// of them, which is why the config is consulted first.
+const DEFAULT_SRC_DIRS = ['src', 'app', 'lib', 'R', 'inst'];
+
+// Walk depth measured from EACH srcDir root, not from cwd — so this is not the
+// same quantity as the extractor's cwd-relative `maxDepth` and must not be read
+// from it. A standard Maven tree reaches `src/main/java/<group>/<artifact>/…`
+// nine directories below its module root, so the previous ceiling of 8 silently
+// dropped the deepest packages (on macrozheng/mall: every `service/impl/` class).
+const DEFAULT_WALK_DEPTH = 12;
+
+/**
+ * Source directories declared in the project's own config, or null when there
+ * is no readable config. Read directly rather than through `loadConfig`, which
+ * can fetch `extends` over the network and spawn a child process — neither is
+ * acceptable inside a graph build.
+ */
+function _configuredSrcDirs(cwd) {
+  try {
+    const raw = fs.readFileSync(path.join(cwd, 'gen-context.config.json'), 'utf8');
+    const cfg = JSON.parse(raw);
+    if (Array.isArray(cfg.srcDirs) && cfg.srcDirs.length > 0) return cfg.srcDirs;
+  } catch (_) { /* absent or unparsable — fall back to the defaults */ }
+  return null;
+}
+
 /**
  * Build a dependency graph scoped to a single cwd by walking all JS/TS/Py/Go
  * files under srcDirs. Useful for the MCP tool handler.
+ *
+ * srcDirs resolution order: explicit `opts.srcDirs` → `gen-context.config.json`
+ * → DEFAULT_SRC_DIRS. Without the config step the graph is empty on any repo
+ * whose sources do not sit under a conventionally-named directory.
  *
  * @param {string} cwd
  * @param {object} [opts]
  * @param {string[]} [opts.srcDirs]
  * @param {string[]} [opts.exclude]
+ * @param {number}   [opts.maxDepth] - walk depth from each srcDir root
  * @returns {{ forward: Map<string,string[]>, reverse: Map<string,string[]> }}
  */
 function buildFromCwd(cwd, opts) {
   // R-package layouts use `R/` and `inst/`; Shiny apps put helpers in `R/`.
   // The existence check below makes these no-ops in non-R projects.
-  const { srcDirs = ['src', 'app', 'lib', 'R', 'inst'], exclude = ['node_modules', '.git', 'dist', 'build'] } = opts || {};
+  const {
+    srcDirs = _configuredSrcDirs(cwd) || DEFAULT_SRC_DIRS,
+    exclude = ['node_modules', '.git', 'dist', 'build'],
+    maxDepth = DEFAULT_WALK_DEPTH,
+  } = opts || {};
   const excludeSet = new Set(exclude);
 
   function walkDir(dir, depth) {
-    if (depth > 8) return [];
+    if (depth > maxDepth) return [];
     let entries;
     try { entries = fs.readdirSync(dir, { withFileTypes: true }); } catch (_) { return []; }
     const out = [];
@@ -500,4 +536,4 @@ function buildFromCwd(cwd, opts) {
   return build(files, cwd, ctx);
 }
 
-module.exports = { build, buildFromCwd, extractFileDeps, normalizePath, loadAliasMap, resolveAlias };
+module.exports = { build, buildFromCwd, extractFileDeps, normalizePath, loadAliasMap, resolveAlias, _configuredSrcDirs, DEFAULT_SRC_DIRS, DEFAULT_WALK_DEPTH };

--- a/test/integration/graph-srcdirs-depth.test.js
+++ b/test/integration/graph-srcdirs-depth.test.js
@@ -1,0 +1,143 @@
+'use strict';
+
+/**
+ * Regression tests for the dependency-graph walk (#560).
+ *
+ * `buildFromCwd` hard-coded both the source directory list and the walk depth,
+ * so the graph came out empty on any repo whose sources do not sit under
+ * src/app/lib (every Maven/Gradle module), and the deepest packages were
+ * dropped even when the right directories were walked.
+ *
+ * Each acceptance criterion gets a test that fails against the pre-fix code.
+ */
+
+const fs = require('fs');
+const os = require('os');
+const path = require('path');
+const assert = require('assert');
+
+const {
+  buildFromCwd, _configuredSrcDirs, DEFAULT_SRC_DIRS, DEFAULT_WALK_DEPTH,
+} = require('../../src/graph/builder');
+
+let passed = 0;
+let failed = 0;
+
+function test(name, fn) {
+  try { fn(); console.log(`  PASS  ${name}`); passed++; }
+  catch (e) { console.log(`  FAIL  ${name}\n        ${e.message}`); failed++; }
+}
+
+function tmpRepo() {
+  return fs.mkdtempSync(path.join(os.tmpdir(), 'sigmap-graph-'));
+}
+function write(root, rel, body) {
+  const abs = path.join(root, rel);
+  fs.mkdirSync(path.dirname(abs), { recursive: true });
+  fs.writeFileSync(abs, body);
+  return abs;
+}
+const rm = (d) => fs.rmSync(d, { recursive: true, force: true });
+const nodes = (g) => [...g.reverse.keys()];
+const findNode = (g, name) => nodes(g).find((k) => k.toLowerCase().includes(name.toLowerCase()));
+const importersOf = (g, name) => {
+  const k = findNode(g, name);
+  return k ? (g.reverse.get(k) || []) : null;
+};
+
+/** A Maven module whose sources sit 9 directories below the module root. */
+function mavenFixture(root) {
+  const pkg = 'app-core/src/main/java/com/example/app/core/service';
+  write(root, `${pkg}/PaymentService.java`,
+    'package com.example.app.core.service;\npublic interface PaymentService { void charge(); }\n');
+  write(root, `${pkg}/impl/PaymentServiceImpl.java`,
+    'package com.example.app.core.service.impl;\n' +
+    'import com.example.app.core.service.PaymentService;\n' +
+    'public class PaymentServiceImpl implements PaymentService { public void charge() {} }\n');
+  fs.writeFileSync(path.join(root, 'gen-context.config.json'),
+    JSON.stringify({ srcDirs: ['app-core'] }, null, 2));
+}
+
+// ---------------------------------------------------------------------------
+// srcDirs resolution
+// ---------------------------------------------------------------------------
+
+test('srcDirs are read from gen-context.config.json when opts omits them', () => {
+  const root = tmpRepo();
+  mavenFixture(root);
+  const g = buildFromCwd(root);
+  assert.ok(nodes(g).length > 0, 'graph must not be empty on a Maven-shaped repo');
+  assert.ok(findNode(g, 'PaymentService.java'), 'the interface must be indexed');
+  rm(root);
+});
+
+test('explicit opts.srcDirs still wins over the config file', () => {
+  const root = tmpRepo();
+  mavenFixture(root);
+  write(root, 'other/Thing.java', 'package other;\npublic class Thing {}\n');
+  const g = buildFromCwd(root, { srcDirs: ['other'] });
+  assert.ok(findNode(g, 'Thing.java'), 'the explicitly requested dir must be walked');
+  assert.ok(!findNode(g, 'PaymentService.java'), 'the config dir must not be walked when opts override');
+  rm(root);
+});
+
+test('with no config and no opts the historical defaults are unchanged', () => {
+  const root = tmpRepo();
+  write(root, 'src/a.js', "const b = require('./b');\n");
+  write(root, 'src/b.js', 'module.exports = {};\n');
+  assert.strictEqual(_configuredSrcDirs(root), null, 'no config → null');
+  const g = buildFromCwd(root);
+  assert.ok(findNode(g, 'a.js') && findNode(g, 'b.js'), 'src/ must still be walked by default');
+  assert.ok(DEFAULT_SRC_DIRS.includes('src'), 'default list must still contain src');
+  rm(root);
+});
+
+test('an unparsable config falls back to the defaults instead of throwing', () => {
+  const root = tmpRepo();
+  write(root, 'src/a.js', 'module.exports = 1;\n');
+  fs.writeFileSync(path.join(root, 'gen-context.config.json'), '{ not json');
+  assert.strictEqual(_configuredSrcDirs(root), null);
+  assert.doesNotThrow(() => buildFromCwd(root));
+  rm(root);
+});
+
+// ---------------------------------------------------------------------------
+// Walk depth
+// ---------------------------------------------------------------------------
+
+test('files deeper than the old 8-directory ceiling are indexed', () => {
+  const root = tmpRepo();
+  mavenFixture(root);
+  const g = buildFromCwd(root);
+  const impl = findNode(g, 'PaymentServiceImpl.java');
+  assert.ok(impl, 'a file 9 directories below the srcDir root must be indexed');
+  rm(root);
+});
+
+test('maxDepth is honoured when supplied', () => {
+  const root = tmpRepo();
+  mavenFixture(root);
+  const shallow = buildFromCwd(root, { maxDepth: 2 });
+  assert.ok(!findNode(shallow, 'PaymentService.java'), 'a tight maxDepth must exclude deep files');
+  assert.ok(DEFAULT_WALK_DEPTH > 8, 'the default must clear a standard Maven tree');
+  rm(root);
+});
+
+// ---------------------------------------------------------------------------
+// End to end: the reason this matters
+// ---------------------------------------------------------------------------
+
+test('Java package imports resolve to real importers', () => {
+  const root = tmpRepo();
+  mavenFixture(root);
+  const g = buildFromCwd(root);
+  const imps = importersOf(g, 'PaymentService.java');
+  assert.ok(imps, 'the imported interface must be a graph node');
+  assert.strictEqual(imps.length, 1, `expected 1 importer, got ${imps.length}`);
+  assert.ok(imps[0].toLowerCase().includes('paymentserviceimpl'), 'the impl must be recorded as the importer');
+  rm(root);
+});
+
+console.log('');
+console.log(`${passed} passed, ${failed} failed`);
+if (failed > 0) process.exit(1);

--- a/version.json
+++ b/version.json
@@ -5,7 +5,7 @@
   "languages": 33,
   "extractors": 43,
   "mcp_tools": 21,
-  "tests": 140,
+  "tests": 141,
   "metrics": {
     "hit_at_5": 0.811,
     "baseline_hit_at_5": 0.136,


### PR DESCRIPTION
Closes #560. First step of the revised implementation plan (W1).

## Problem

`buildFromCwd` hard-coded both the source directory list and the walk depth, so the dependency graph came out **empty** on any repo whose sources do not sit under `src`/`app`/`lib`/`R`/`inst` — every Maven/Gradle multi-module project. The project's own `srcDirs` were never consulted.

On `macrozheng/mall` (524 Java files, 8 modules):

```js
buildFromCwd(cwd)                      // ->   0 graph nodes
buildFromCwd(cwd, { srcDirs: [...] })  // -> 493 nodes, 319 with importers
```

Java package-import resolution **already worked** — `builder.js` maps `com.macro.mall.X` → `com/macro/mall/X.java`. It was simply never reached.

A second hard-coded ceiling, `depth > 8`, then dropped the deepest packages even when the right directories were walked. Measured on mall: 17 files (3%) — but they are every `service/impl/` class, the implementations that matter most.

## Why it matters

`imported_by_count` was 0 for every Java file, so everything downstream was silently dead on JVM repos:

- `sigmap --impact <file>` reported "No importers found"
- import-graph centrality contributed nothing to ranking
- blast-radius scoring weighted by caller centrality degenerated to zero

Same class of defect as the extractor caps in #551 — a structural assumption that a repo is JS-shaped and shallow.

## Change

- `srcDirs` resolve as **explicit opts → `gen-context.config.json` → historical defaults**
- `maxDepth` becomes an option, default **12**, enough to clear `<module>/src/main/java/<group>/<artifact>/…`

Two deliberate calls:

**The walk depth is measured from each srcDir root, not from cwd**, so it is *not* read from the extractor's cwd-relative `maxDepth` — same word, different quantity. Conflating them would silently under-walk.

**The config is read directly rather than via `loadConfig`**, which can fetch `extends` over HTTPS and spawn a child process. Neither belongs inside a graph build, and both would surface in the supply-chain audit.

## Verification

On mall, with no opts passed:

| | before | after |
|---|---:|---:|
| Java graph nodes | 0 | **524** |
| nodes with importers | 0 | **341** |
| `OmsPromotionService.java` | "No importers found" | **2 real importers** |

## Tests

7 new cases in `test/integration/graph-srcdirs-depth.test.js`: config-sourced srcDirs, explicit opts still winning, unchanged defaults with no config, unparsable config falling back rather than throwing, depth-9 files indexed, `maxDepth` honoured, and a Java package import resolving end to end on a Maven-shaped fixture.

**6 of the 7 fail against the pre-fix implementation** (verified by stashing). The one that passes both ways is the "explicit opts wins" guard — behaviour that must not change.

Full suite: **135 passed, 0 failed**. Bundle regenerated; `version.json` test count synced 140 → 141.

One flake seen and chased down: `coverage-score.test.js` hit a `spawnSync ETIMEDOUT` under full-suite load. It passes 3/3 in isolation, and the graph walk is not slower (158 nodes in 20–41ms at either depth on this repo), so it is unrelated to this change.

## Not in this PR

W2–W3 of the plan — `callsInRange` discards every `receiver.method(` call, which is **58% of call sites in mall-portal**. That is the remaining half of why the Java call graph is empty, and it needs receiver-type resolution rather than a config fix.