### PR TITLE
fix(graph): resolve receiver-typed Java calls so the call graph sees them

### DIFF
--- a/gen-context.js
+++ b/gen-context.js
@@ -12073,6 +12073,13 @@ __factories["./src/graph/call-graph"] = function(module, exports) {
   // Java: methods + constructors with braced bodies. Statement-shaped matches
   // (calls, control flow) are rejected because their `)` is followed by `;`,
   // and keyword headers (`if`, `while`, …) fall to the NON_CALL guard.
+  // Words that can precede `name(` in a STATEMENT, so their presence means the
+  // line is not a method declaration.
+  const STMT_KEYWORDS = new Set([
+    'return', 'throw', 'else', 'do', 'try', 'case', 'yield', 'assert', 'new',
+    'if', 'while', 'for', 'switch', 'catch', 'synchronized', 'instanceof', 'await',
+  ]);
+
   function javaDefs(masked) {
     const defs = [];
     const seen = new Set();
@@ -12089,11 +12096,24 @@ __factories["./src/graph/call-graph"] = function(module, exports) {
       // skip `throws A, B` up to the body `{` (same line — multi-line headers are skipped)
       let k = close + 1;
       while (k < masked.length && masked[k] !== '{' && masked[k] !== ';' && masked[k] !== '\n' && masked[k] !== '=') k++;
-      if (masked[k] !== '{') continue;
+      // A `;` here is an interface or abstract method DECLARATION. It owns no body,
+      // so it emits no calls — but in Spring the declared interface is what callers
+      // name, so without it as a node every controller→service edge has no target.
+      // Recorded with an empty body range: can receive edges, never produces them.
+      // `before` is everything between line start and the method name. A real
+      // declaration has modifiers or a return type there (`void chargeCard(`);
+      // a call statement has only whitespace (`identity(1);`) or a statement
+      // keyword (`return helper(a);`) — neither may be read as a declaration,
+      // or the call resolves to a phantom local def instead of the real target.
+      const headWord = (before.match(/([A-Za-z_$][\w$]*)\s*$/) || [])[1];
+      const isDecl = masked[k] === ';' && /\S/.test(before) && !STMT_KEYWORDS.has(headWord);
+      if (masked[k] !== '{' && !isDecl) continue;
       const key = name + ':' + k;
       if (seen.has(key)) continue;
       seen.add(key);
-      defs.push({ name, line: lineAt(masked, m.index + 1), bodyStart: k, bodyEnd: matchDelim(masked, k, '{', '}') });
+      defs.push(isDecl
+        ? { name, line: lineAt(masked, m.index + 1), bodyStart: k, bodyEnd: k }
+        : { name, line: lineAt(masked, m.index + 1), bodyStart: k, bodyEnd: matchDelim(masked, k, '{', '}') });
     }
     return defs;
   }
@@ -12147,7 +12167,7 @@ __factories["./src/graph/call-graph"] = function(module, exports) {
     const re = /([A-Za-z_$][\w$]*)\s*\(/g;
     let m;
     while ((m = re.exec(slice)) !== null) {
-      // skip a `.name(` method access (can't resolve the receiver deterministically)
+      // skip a `.name(` method access — resolved separately via receiverCallsInRange
       const before = slice[m.index - 1];
       if (before === '.') continue;
       if (!NON_CALL.has(m[1])) names.add(m[1]);
@@ -12155,16 +12175,75 @@ __factories["./src/graph/call-graph"] = function(module, exports) {
     return names;
   }
 
+  // Collect `receiver.method(` pairs within [start,end). A chained or computed
+  // receiver (`a.b().c(`, `arr[0].c(`) is skipped: only a plain identifier can be
+  // looked up in the declaration map, and guessing is worse than no edge.
+  function receiverCallsInRange(masked, start, end) {
+    const slice = masked.slice(start, end);
+    const out = [];
+    const re = /([A-Za-z_$][\w$]*)\s*\.\s*([A-Za-z_$][\w$]*)\s*\(/g;
+    let m;
+    while ((m = re.exec(slice)) !== null) {
+      const before = slice[m.index - 1];
+      if (before === '.' || before === ')' || before === ']') continue;
+      if (NON_CALL.has(m[2])) continue;
+      out.push({ receiver: m[1], method: m[2] });
+    }
+    return out;
+  }
+
+  // `private UserService userService;` / `UserService svc = new UserService();`
+  // / `for (OmsOrderItem item : list)` → { userService: 'UserService', … }.
+  // Declarations only: a bare assignment carries no type and is not inferred.
+  const DECL_RE = /(?:^|[;{}(,\n])\s*(?:(?:public|private|protected|static|final|volatile|transient)\s+)*([A-Z][\w$]*)(?:\s*<[^>;=(){}]*>)?(?:\s*\[\s*\])?\s+([a-z_$][\w$]*)\s*(?=[;=:)])/g;
+
+  function buildTypeMap(masked) {
+    const map = new Map();
+    let m;
+    DECL_RE.lastIndex = 0;
+    while ((m = DECL_RE.exec(masked)) !== null) {
+      const [, type, name] = m;
+      if (JVM_KEYWORDS.has(type) || JVM_KEYWORDS.has(name)) continue;
+      if (!map.has(name)) map.set(name, type);   // first declaration wins — deterministic
+    }
+    return map;
+  }
+
+  // Type names that are never a user class, so never a resolvable receiver type.
+  const JVM_KEYWORDS = new Set([
+    'return', 'new', 'if', 'else', 'for', 'while', 'switch', 'case', 'throw', 'catch',
+    'String', 'Integer', 'Long', 'Boolean', 'Double', 'Float', 'Object', 'List', 'Map',
+    'Set', 'Collection', 'Optional', 'Override', 'Autowired', 'Resource', 'Deprecated',
+  ]);
+
   // ── Public API ───────────────────────────────────────────────────────────────
 
-  function _walk(dir, excludeSet, out, depth) {
-    if (depth > 8) return;
+  // Walk depth from each srcDir root (not from cwd). A Maven module reaches
+  // `src/main/java/<group>/<artifact>/service/impl` nine directories down, so the
+  // previous ceiling of 8 never saw the classes that own the method bodies.
+  const DEFAULT_WALK_DEPTH = 12;
+
+  /**
+   * Source directories declared in the project's own config, or null. Read
+   * directly rather than through `loadConfig`, which can fetch `extends` over the
+   * network and spawn a child process — neither belongs inside a graph build.
+   */
+  function _configuredSrcDirs(cwd) {
+    try {
+      const cfg = JSON.parse(fs.readFileSync(path.join(cwd, 'gen-context.config.json'), 'utf8'));
+      if (Array.isArray(cfg.srcDirs) && cfg.srcDirs.length > 0) return cfg.srcDirs;
+    } catch (_) { /* absent or unparsable — fall back to the defaults */ }
+    return null;
+  }
+
+  function _walk(dir, excludeSet, out, depth, maxDepth) {
+    if (depth > (maxDepth === undefined ? DEFAULT_WALK_DEPTH : maxDepth)) return;
     let entries;
     try { entries = fs.readdirSync(dir, { withFileTypes: true }); } catch (_) { return; }
     for (const e of entries) {
       if (excludeSet.has(e.name) || e.name.startsWith('.')) continue;
       const full = path.join(dir, e.name);
-      if (e.isDirectory()) _walk(full, excludeSet, out, depth + 1);
+      if (e.isDirectory()) _walk(full, excludeSet, out, depth + 1, maxDepth);
       else if (e.isFile()) {
         const ext = path.extname(e.name).toLowerCase();
         if (JS_EXTS.has(ext) || PY_EXTS.has(ext) || JAVA_EXTS.has(ext) || GO_EXTS.has(ext) || RS_EXTS.has(ext)) out.push(full);
@@ -12190,9 +12269,13 @@ __factories["./src/graph/call-graph"] = function(module, exports) {
     const excludeSet = new Set(opts.exclude || ['node_modules', '.git', 'dist', 'build', 'coverage', 'vendor']);
     let files = opts.files ? opts.files.map((f) => path.resolve(f)) : [];
     if (!opts.files) {
-      for (const sd of (opts.srcDirs || ['src', 'app', 'lib'])) {
+      // Same resolution order as the dependency graph (#560): explicit opts →
+      // the project's own config → the historical defaults. Without the config
+      // step this is empty on any repo whose sources are not under src/app/lib.
+      const srcDirs = opts.srcDirs || _configuredSrcDirs(cwd) || ['src', 'app', 'lib'];
+      for (const sd of srcDirs) {
         const abs = path.resolve(cwd, sd);
-        if (fs.existsSync(abs)) _walk(abs, excludeSet, files, 0);
+        if (fs.existsSync(abs)) _walk(abs, excludeSet, files, 0, opts.maxDepth);
       }
     }
 
@@ -12205,6 +12288,18 @@ __factories["./src/graph/call-graph"] = function(module, exports) {
     const defsByName = new Map();     // absFile → Map<name, symbolId[]>
     const normToAbs = new Map();      // normalized abs → abs
     const defs = new Map();           // symbolId → {file,name,line}
+
+    // JVM convention: a public type lives in a file of the same name. This is the
+    // deterministic type→file mapping receiver resolution needs, with no AST.
+    const fileByTypeName = new Map();   // 'UserService' → [absFile]
+    for (const f of files) {
+      const ext = path.extname(f).toLowerCase();
+      if (JAVA_EXTS.has(ext)) {
+        const base = path.basename(f, path.extname(f));
+        if (!fileByTypeName.has(base)) fileByTypeName.set(base, []);
+        fileByTypeName.get(base).push(f);
+      }
+    }
 
     for (const f of files) {
       normToAbs.set(normalizePath(path.resolve(f)), path.resolve(f));
@@ -12225,12 +12320,20 @@ __factories["./src/graph/call-graph"] = function(module, exports) {
 
     const forward = new Map();
     const reverse = new Map();
-    const addEdge = (from, to) => {
+    // Additive: `forward`/`reverse` keep their existing shape, so every current
+    // consumer is unaffected. Confidence is looked up by "from\u0000to".
+    const edgeConfidence = new Map();
+    const addEdge = (from, to, confidence) => {
       if (from === to) return;
       if (!forward.has(from)) forward.set(from, new Set());
       forward.get(from).add(to);
       if (!reverse.has(to)) reverse.set(to, new Set());
       reverse.get(to).add(from);
+      if (confidence) {
+        const k = from + '\u0000' + to;
+        // A 'high' resolution never loses to a later 'medium' one.
+        if (edgeConfidence.get(k) !== 'high') edgeConfidence.set(k, confidence);
+      }
     };
 
     for (const [f, fileDefs] of perFileDefs.entries()) {
@@ -12248,17 +12351,50 @@ __factories["./src/graph/call-graph"] = function(module, exports) {
           .sort();
         importedAbs.push(...siblings);
       }
+      // Receiver types come from declarations anywhere in the file: fields are
+      // declared outside any method body, locals inside one.
+      const typeMap = JAVA_EXTS.has(ext) ? buildTypeMap(masked) : null;
+      // Types reachable from this file, by name — imports first, then same-package
+      // siblings, so an import always wins over a coincidental sibling name.
+      const scopeByTypeName = new Map();
+      if (typeMap) {
+        for (const imp of importedAbs) {
+          const base = path.basename(imp, path.extname(imp));
+          if (!scopeByTypeName.has(base)) scopeByTypeName.set(base, imp);
+        }
+      }
+
       for (const d of fileDefs) {
         const callerId = symId(cwd, f, d.name);
         if (!forward.has(callerId)) forward.set(callerId, new Set()); // ensure node exists
         const callees = callsInRange(masked, d.bodyStart, d.bodyEnd);
         for (const nm of callees) {
           const local = (defsByName.get(f) || new Map()).get(nm);
-          if (local && local.length) { for (const id of local) addEdge(callerId, id); continue; }
+          if (local && local.length) { for (const id of local) addEdge(callerId, id, 'high'); continue; }
           for (const imp of importedAbs) {
             const ids = (defsByName.get(imp) || new Map()).get(nm);
-            if (ids && ids.length) { for (const id of ids) addEdge(callerId, id); break; }
+            if (ids && ids.length) { for (const id of ids) addEdge(callerId, id, 'high'); break; }
           }
+        }
+
+        // `receiver.method(` — resolve the receiver's declared type to a file.
+        if (!typeMap) continue;
+        for (const { receiver, method } of receiverCallsInRange(masked, d.bodyStart, d.bodyEnd)) {
+          // A receiver that is itself a type name is a static call: `Foo.bar()`.
+          const typeName = typeMap.get(receiver)
+            || (fileByTypeName.has(receiver) ? receiver : null);
+          if (!typeName) continue;                 // unknown receiver → no edge, never a guess
+
+          let target = scopeByTypeName.get(typeName);
+          let confidence = 'high';                 // typed receiver, resolved in scope
+          if (!target) {
+            const candidates = fileByTypeName.get(typeName) || [];
+            if (candidates.length !== 1) continue; // ambiguous or absent → no edge
+            target = candidates[0];
+            confidence = 'medium';                 // type known, but not in this file's scope
+          }
+          const ids = (defsByName.get(target) || new Map()).get(method);
+          if (ids && ids.length) for (const id of ids) addEdge(callerId, id, confidence);
         }
       }
     }
@@ -12268,7 +12404,7 @@ __factories["./src/graph/call-graph"] = function(module, exports) {
       for (const [k, set] of mapOfSets.entries()) out.set(k, [...set]);
       return out;
     };
-    return { forward: toArr(forward), reverse: toArr(reverse), defs };
+    return { forward: toArr(forward), reverse: toArr(reverse), defs, edgeConfidence };
   }
 
   /**
@@ -12390,7 +12526,7 @@ __factories["./src/graph/call-graph"] = function(module, exports) {
   }
 
   module.exports = {
-    buildCallGraph, buildCallFileGraph, methodImpact, methodCallees,
+    buildCallGraph, buildTypeMap, receiverCallsInRange, DEFAULT_WALK_DEPTH, buildCallFileGraph, methodImpact, methodCallees,
     formatCallGraph, formatCallGraphJSON,
     extractDefs, maskJs, maskPy, maskRust,
   };

--- a/src/graph/call-graph.js
+++ b/src/graph/call-graph.js
@@ -248,6 +248,13 @@ function goDefs(masked) {
 // Java: methods + constructors with braced bodies. Statement-shaped matches
 // (calls, control flow) are rejected because their `)` is followed by `;`,
 // and keyword headers (`if`, `while`, …) fall to the NON_CALL guard.
+// Words that can precede `name(` in a STATEMENT, so their presence means the
+// line is not a method declaration.
+const STMT_KEYWORDS = new Set([
+  'return', 'throw', 'else', 'do', 'try', 'case', 'yield', 'assert', 'new',
+  'if', 'while', 'for', 'switch', 'catch', 'synchronized', 'instanceof', 'await',
+]);
+
 function javaDefs(masked) {
   const defs = [];
   const seen = new Set();
@@ -264,11 +271,24 @@ function javaDefs(masked) {
     // skip `throws A, B` up to the body `{` (same line — multi-line headers are skipped)
     let k = close + 1;
     while (k < masked.length && masked[k] !== '{' && masked[k] !== ';' && masked[k] !== '\n' && masked[k] !== '=') k++;
-    if (masked[k] !== '{') continue;
+    // A `;` here is an interface or abstract method DECLARATION. It owns no body,
+    // so it emits no calls — but in Spring the declared interface is what callers
+    // name, so without it as a node every controller→service edge has no target.
+    // Recorded with an empty body range: can receive edges, never produces them.
+    // `before` is everything between line start and the method name. A real
+    // declaration has modifiers or a return type there (`void chargeCard(`);
+    // a call statement has only whitespace (`identity(1);`) or a statement
+    // keyword (`return helper(a);`) — neither may be read as a declaration,
+    // or the call resolves to a phantom local def instead of the real target.
+    const headWord = (before.match(/([A-Za-z_$][\w$]*)\s*$/) || [])[1];
+    const isDecl = masked[k] === ';' && /\S/.test(before) && !STMT_KEYWORDS.has(headWord);
+    if (masked[k] !== '{' && !isDecl) continue;
     const key = name + ':' + k;
     if (seen.has(key)) continue;
     seen.add(key);
-    defs.push({ name, line: lineAt(masked, m.index + 1), bodyStart: k, bodyEnd: matchDelim(masked, k, '{', '}') });
+    defs.push(isDecl
+      ? { name, line: lineAt(masked, m.index + 1), bodyStart: k, bodyEnd: k }
+      : { name, line: lineAt(masked, m.index + 1), bodyStart: k, bodyEnd: matchDelim(masked, k, '{', '}') });
   }
   return defs;
 }
@@ -322,7 +342,7 @@ function callsInRange(masked, start, end) {
   const re = /([A-Za-z_$][\w$]*)\s*\(/g;
   let m;
   while ((m = re.exec(slice)) !== null) {
-    // skip a `.name(` method access (can't resolve the receiver deterministically)
+    // skip a `.name(` method access — resolved separately via receiverCallsInRange
     const before = slice[m.index - 1];
     if (before === '.') continue;
     if (!NON_CALL.has(m[1])) names.add(m[1]);
@@ -330,16 +350,75 @@ function callsInRange(masked, start, end) {
   return names;
 }
 
+// Collect `receiver.method(` pairs within [start,end). A chained or computed
+// receiver (`a.b().c(`, `arr[0].c(`) is skipped: only a plain identifier can be
+// looked up in the declaration map, and guessing is worse than no edge.
+function receiverCallsInRange(masked, start, end) {
+  const slice = masked.slice(start, end);
+  const out = [];
+  const re = /([A-Za-z_$][\w$]*)\s*\.\s*([A-Za-z_$][\w$]*)\s*\(/g;
+  let m;
+  while ((m = re.exec(slice)) !== null) {
+    const before = slice[m.index - 1];
+    if (before === '.' || before === ')' || before === ']') continue;
+    if (NON_CALL.has(m[2])) continue;
+    out.push({ receiver: m[1], method: m[2] });
+  }
+  return out;
+}
+
+// `private UserService userService;` / `UserService svc = new UserService();`
+// / `for (OmsOrderItem item : list)` → { userService: 'UserService', … }.
+// Declarations only: a bare assignment carries no type and is not inferred.
+const DECL_RE = /(?:^|[;{}(,\n])\s*(?:(?:public|private|protected|static|final|volatile|transient)\s+)*([A-Z][\w$]*)(?:\s*<[^>;=(){}]*>)?(?:\s*\[\s*\])?\s+([a-z_$][\w$]*)\s*(?=[;=:)])/g;
+
+function buildTypeMap(masked) {
+  const map = new Map();
+  let m;
+  DECL_RE.lastIndex = 0;
+  while ((m = DECL_RE.exec(masked)) !== null) {
+    const [, type, name] = m;
+    if (JVM_KEYWORDS.has(type) || JVM_KEYWORDS.has(name)) continue;
+    if (!map.has(name)) map.set(name, type);   // first declaration wins — deterministic
+  }
+  return map;
+}
+
+// Type names that are never a user class, so never a resolvable receiver type.
+const JVM_KEYWORDS = new Set([
+  'return', 'new', 'if', 'else', 'for', 'while', 'switch', 'case', 'throw', 'catch',
+  'String', 'Integer', 'Long', 'Boolean', 'Double', 'Float', 'Object', 'List', 'Map',
+  'Set', 'Collection', 'Optional', 'Override', 'Autowired', 'Resource', 'Deprecated',
+]);
+
 // ── Public API ───────────────────────────────────────────────────────────────
 
-function _walk(dir, excludeSet, out, depth) {
-  if (depth > 8) return;
+// Walk depth from each srcDir root (not from cwd). A Maven module reaches
+// `src/main/java/<group>/<artifact>/service/impl` nine directories down, so the
+// previous ceiling of 8 never saw the classes that own the method bodies.
+const DEFAULT_WALK_DEPTH = 12;
+
+/**
+ * Source directories declared in the project's own config, or null. Read
+ * directly rather than through `loadConfig`, which can fetch `extends` over the
+ * network and spawn a child process — neither belongs inside a graph build.
+ */
+function _configuredSrcDirs(cwd) {
+  try {
+    const cfg = JSON.parse(fs.readFileSync(path.join(cwd, 'gen-context.config.json'), 'utf8'));
+    if (Array.isArray(cfg.srcDirs) && cfg.srcDirs.length > 0) return cfg.srcDirs;
+  } catch (_) { /* absent or unparsable — fall back to the defaults */ }
+  return null;
+}
+
+function _walk(dir, excludeSet, out, depth, maxDepth) {
+  if (depth > (maxDepth === undefined ? DEFAULT_WALK_DEPTH : maxDepth)) return;
   let entries;
   try { entries = fs.readdirSync(dir, { withFileTypes: true }); } catch (_) { return; }
   for (const e of entries) {
     if (excludeSet.has(e.name) || e.name.startsWith('.')) continue;
     const full = path.join(dir, e.name);
-    if (e.isDirectory()) _walk(full, excludeSet, out, depth + 1);
+    if (e.isDirectory()) _walk(full, excludeSet, out, depth + 1, maxDepth);
     else if (e.isFile()) {
       const ext = path.extname(e.name).toLowerCase();
       if (JS_EXTS.has(ext) || PY_EXTS.has(ext) || JAVA_EXTS.has(ext) || GO_EXTS.has(ext) || RS_EXTS.has(ext)) out.push(full);
@@ -365,9 +444,13 @@ function buildCallGraph(cwd, opts = {}) {
   const excludeSet = new Set(opts.exclude || ['node_modules', '.git', 'dist', 'build', 'coverage', 'vendor']);
   let files = opts.files ? opts.files.map((f) => path.resolve(f)) : [];
   if (!opts.files) {
-    for (const sd of (opts.srcDirs || ['src', 'app', 'lib'])) {
+    // Same resolution order as the dependency graph (#560): explicit opts →
+    // the project's own config → the historical defaults. Without the config
+    // step this is empty on any repo whose sources are not under src/app/lib.
+    const srcDirs = opts.srcDirs || _configuredSrcDirs(cwd) || ['src', 'app', 'lib'];
+    for (const sd of srcDirs) {
       const abs = path.resolve(cwd, sd);
-      if (fs.existsSync(abs)) _walk(abs, excludeSet, files, 0);
+      if (fs.existsSync(abs)) _walk(abs, excludeSet, files, 0, opts.maxDepth);
     }
   }
 
@@ -380,6 +463,18 @@ function buildCallGraph(cwd, opts = {}) {
   const defsByName = new Map();     // absFile → Map<name, symbolId[]>
   const normToAbs = new Map();      // normalized abs → abs
   const defs = new Map();           // symbolId → {file,name,line}
+
+  // JVM convention: a public type lives in a file of the same name. This is the
+  // deterministic type→file mapping receiver resolution needs, with no AST.
+  const fileByTypeName = new Map();   // 'UserService' → [absFile]
+  for (const f of files) {
+    const ext = path.extname(f).toLowerCase();
+    if (JAVA_EXTS.has(ext)) {
+      const base = path.basename(f, path.extname(f));
+      if (!fileByTypeName.has(base)) fileByTypeName.set(base, []);
+      fileByTypeName.get(base).push(f);
+    }
+  }
 
   for (const f of files) {
     normToAbs.set(normalizePath(path.resolve(f)), path.resolve(f));
@@ -400,12 +495,20 @@ function buildCallGraph(cwd, opts = {}) {
 
   const forward = new Map();
   const reverse = new Map();
-  const addEdge = (from, to) => {
+  // Additive: `forward`/`reverse` keep their existing shape, so every current
+  // consumer is unaffected. Confidence is looked up by "from\u0000to".
+  const edgeConfidence = new Map();
+  const addEdge = (from, to, confidence) => {
     if (from === to) return;
     if (!forward.has(from)) forward.set(from, new Set());
     forward.get(from).add(to);
     if (!reverse.has(to)) reverse.set(to, new Set());
     reverse.get(to).add(from);
+    if (confidence) {
+      const k = from + '\u0000' + to;
+      // A 'high' resolution never loses to a later 'medium' one.
+      if (edgeConfidence.get(k) !== 'high') edgeConfidence.set(k, confidence);
+    }
   };
 
   for (const [f, fileDefs] of perFileDefs.entries()) {
@@ -423,17 +526,50 @@ function buildCallGraph(cwd, opts = {}) {
         .sort();
       importedAbs.push(...siblings);
     }
+    // Receiver types come from declarations anywhere in the file: fields are
+    // declared outside any method body, locals inside one.
+    const typeMap = JAVA_EXTS.has(ext) ? buildTypeMap(masked) : null;
+    // Types reachable from this file, by name — imports first, then same-package
+    // siblings, so an import always wins over a coincidental sibling name.
+    const scopeByTypeName = new Map();
+    if (typeMap) {
+      for (const imp of importedAbs) {
+        const base = path.basename(imp, path.extname(imp));
+        if (!scopeByTypeName.has(base)) scopeByTypeName.set(base, imp);
+      }
+    }
+
     for (const d of fileDefs) {
       const callerId = symId(cwd, f, d.name);
       if (!forward.has(callerId)) forward.set(callerId, new Set()); // ensure node exists
       const callees = callsInRange(masked, d.bodyStart, d.bodyEnd);
       for (const nm of callees) {
         const local = (defsByName.get(f) || new Map()).get(nm);
-        if (local && local.length) { for (const id of local) addEdge(callerId, id); continue; }
+        if (local && local.length) { for (const id of local) addEdge(callerId, id, 'high'); continue; }
         for (const imp of importedAbs) {
           const ids = (defsByName.get(imp) || new Map()).get(nm);
-          if (ids && ids.length) { for (const id of ids) addEdge(callerId, id); break; }
+          if (ids && ids.length) { for (const id of ids) addEdge(callerId, id, 'high'); break; }
         }
+      }
+
+      // `receiver.method(` — resolve the receiver's declared type to a file.
+      if (!typeMap) continue;
+      for (const { receiver, method } of receiverCallsInRange(masked, d.bodyStart, d.bodyEnd)) {
+        // A receiver that is itself a type name is a static call: `Foo.bar()`.
+        const typeName = typeMap.get(receiver)
+          || (fileByTypeName.has(receiver) ? receiver : null);
+        if (!typeName) continue;                 // unknown receiver → no edge, never a guess
+
+        let target = scopeByTypeName.get(typeName);
+        let confidence = 'high';                 // typed receiver, resolved in scope
+        if (!target) {
+          const candidates = fileByTypeName.get(typeName) || [];
+          if (candidates.length !== 1) continue; // ambiguous or absent → no edge
+          target = candidates[0];
+          confidence = 'medium';                 // type known, but not in this file's scope
+        }
+        const ids = (defsByName.get(target) || new Map()).get(method);
+        if (ids && ids.length) for (const id of ids) addEdge(callerId, id, confidence);
       }
     }
   }
@@ -443,7 +579,7 @@ function buildCallGraph(cwd, opts = {}) {
     for (const [k, set] of mapOfSets.entries()) out.set(k, [...set]);
     return out;
   };
-  return { forward: toArr(forward), reverse: toArr(reverse), defs };
+  return { forward: toArr(forward), reverse: toArr(reverse), defs, edgeConfidence };
 }
 
 /**
@@ -565,7 +701,7 @@ function formatCallGraphJSON(result, kind) {
 }
 
 module.exports = {
-  buildCallGraph, buildCallFileGraph, methodImpact, methodCallees,
+  buildCallGraph, buildTypeMap, receiverCallsInRange, DEFAULT_WALK_DEPTH, buildCallFileGraph, methodImpact, methodCallees,
   formatCallGraph, formatCallGraphJSON,
   extractDefs, maskJs, maskPy, maskRust,
 };

--- a/test/integration/java-receiver-calls.test.js
+++ b/test/integration/java-receiver-calls.test.js
@@ -1,0 +1,165 @@
+'use strict';
+
+/**
+ * Regression tests for Java receiver-typed call resolution (#562).
+ *
+ * `callsInRange` discarded every `receiver.method(` call — 58% of call sites in
+ * a real Spring module — so controller→service edges did not exist. Plus
+ * `buildCallGraph` carried its own copies of the srcDirs and depth caps fixed
+ * for the dependency graph in #560.
+ *
+ * Fixtures use distinct caller/callee method names on purpose: when both share
+ * a name, a bare-name lookup makes the caller a seed and `_bfs` filters it out
+ * of its own result. That is pre-existing behaviour, not what these test.
+ */
+
+const fs = require('fs');
+const os = require('os');
+const path = require('path');
+const assert = require('assert');
+
+const {
+  buildCallGraph, buildTypeMap, receiverCallsInRange, extractDefs, maskJs, DEFAULT_WALK_DEPTH,
+} = require('../../src/graph/call-graph');
+
+let passed = 0;
+let failed = 0;
+function test(name, fn) {
+  try { fn(); console.log(`  PASS  ${name}`); passed++; }
+  catch (e) { console.log(`  FAIL  ${name}\n        ${e.message}`); failed++; }
+}
+
+const tmp = () => fs.mkdtempSync(path.join(os.tmpdir(), 'sigmap-callgraph-'));
+const rm = (d) => fs.rmSync(d, { recursive: true, force: true });
+function write(root, rel, body) {
+  const abs = path.join(root, rel);
+  fs.mkdirSync(path.dirname(abs), { recursive: true });
+  fs.writeFileSync(abs, body);
+}
+const edgesOf = (g, sub) => {
+  const id = [...g.forward.keys()].find((k) => k.includes(sub));
+  return id ? (g.forward.get(id) || []) : [];
+};
+
+/** Spring-shaped module: controller → interface, impl 9 dirs deep. */
+function springFixture(root, { typed = true } = {}) {
+  const base = 'app-core/src/main/java/com/example/app/core';
+  write(root, `${base}/service/PaymentService.java`,
+    'package com.example.app.core.service;\n' +
+    'public interface PaymentService {\n    void chargeCard(String id);\n}\n');
+  write(root, `${base}/service/impl/PaymentServiceImpl.java`,
+    'package com.example.app.core.service.impl;\n' +
+    'import com.example.app.core.service.PaymentService;\n' +
+    'public class PaymentServiceImpl implements PaymentService {\n' +
+    '    public void chargeCard(String id) { }\n}\n');
+  write(root, `${base}/controller/PaymentController.java`,
+    'package com.example.app.core.controller;\n' +
+    'import com.example.app.core.service.PaymentService;\n' +
+    'public class PaymentController {\n' +
+    (typed ? '    private PaymentService paymentService;\n' : '') +
+    '    public void handleRequest() {\n        paymentService.chargeCard("x");\n    }\n}\n');
+  fs.writeFileSync(path.join(root, 'gen-context.config.json'),
+    JSON.stringify({ srcDirs: ['app-core'] }, null, 2));
+}
+
+// ---------------------------------------------------------------------------
+// Extraction primitives
+// ---------------------------------------------------------------------------
+
+test('receiverCallsInRange captures receiver.method pairs', () => {
+  const src = 'void f() { userService.authenticate(token); }';
+  const got = receiverCallsInRange(maskJs(src), 0, src.length);
+  assert.deepStrictEqual(got, [{ receiver: 'userService', method: 'authenticate' }]);
+});
+
+test('a chained or computed receiver is skipped, not guessed', () => {
+  const src = 'void f() { a.b().c(); arr[0].d(); }';
+  const got = receiverCallsInRange(maskJs(src), 0, src.length).map((x) => x.method);
+  assert.ok(!got.includes('c'), 'chained call must not be resolved');
+  assert.ok(!got.includes('d'), 'indexed receiver must not be resolved');
+});
+
+test('buildTypeMap reads field and local declarations', () => {
+  const src = 'class C {\n  private UserService userService;\n  void f() { OrderRepo repo = null; }\n}';
+  const tm = buildTypeMap(maskJs(src));
+  assert.strictEqual(tm.get('userService'), 'UserService');
+  assert.strictEqual(tm.get('repo'), 'OrderRepo');
+});
+
+test('interface method declarations are indexed as defs', () => {
+  const src = 'public interface PaymentService {\n    void chargeCard(String id);\n}\n';
+  const names = (extractDefs('PaymentService.java', src) || []).map((d) => d.name);
+  assert.ok(names.includes('chargeCard'), 'a declaration must be a node so callers have a target');
+});
+
+// ---------------------------------------------------------------------------
+// Graph construction
+// ---------------------------------------------------------------------------
+
+test('srcDirs come from gen-context.config.json when opts omit them', () => {
+  const root = tmp(); springFixture(root);
+  const g = buildCallGraph(root);
+  assert.ok(g.defs.size > 0, 'graph must not be empty on a Maven-shaped repo');
+  rm(root);
+});
+
+test('files deeper than the old 8-directory ceiling are scanned', () => {
+  const root = tmp(); springFixture(root);
+  const g = buildCallGraph(root);
+  const impl = [...g.defs.keys()].find((k) => k.includes('PaymentServiceImpl'));
+  assert.ok(impl, 'a class 9 directories deep must be scanned');
+  assert.ok(DEFAULT_WALK_DEPTH > 8, 'default depth must clear a Maven tree');
+  rm(root);
+});
+
+test('receiver.method() produces an edge when the receiver type is declared', () => {
+  const root = tmp(); springFixture(root);
+  const g = buildCallGraph(root);
+  const targets = edgesOf(g, 'PaymentController.java#handleRequest');
+  assert.ok(targets.some((t) => t.includes('PaymentService.java#chargeCard')),
+    `controller must call the service; got ${JSON.stringify(targets)}`);
+  rm(root);
+});
+
+test('an undeclared receiver produces no edge — never a name-only guess', () => {
+  const root = tmp(); springFixture(root, { typed: false });
+  const g = buildCallGraph(root);
+  const targets = edgesOf(g, 'PaymentController.java#handleRequest');
+  assert.ok(!targets.some((t) => t.includes('chargeCard')),
+    'without a declared type the edge must not be invented');
+  rm(root);
+});
+
+test('resolved edges carry a confidence label', () => {
+  const root = tmp(); springFixture(root);
+  const g = buildCallGraph(root);
+  assert.ok(g.edgeConfidence instanceof Map, 'edgeConfidence must be exposed');
+  const vals = new Set(g.edgeConfidence.values());
+  assert.ok(vals.size > 0, 'at least one labelled edge');
+  for (const v of vals) assert.ok(['high', 'medium'].includes(v), `unexpected label: ${v}`);
+  rm(root);
+});
+
+test('forward/reverse keep their existing shape (additive change)', () => {
+  const root = tmp(); springFixture(root);
+  const g = buildCallGraph(root);
+  for (const v of g.forward.values()) assert.ok(Array.isArray(v), 'forward values stay arrays');
+  rm(root);
+});
+
+// ---------------------------------------------------------------------------
+// Other languages unaffected
+// ---------------------------------------------------------------------------
+
+test('JS edges are unchanged by receiver resolution', () => {
+  const root = tmp();
+  write(root, 'src/a.js', "const { helper } = require('./b');\nfunction run() { helper(); }\nmodule.exports = { run };\n");
+  write(root, 'src/b.js', 'function helper() {}\nmodule.exports = { helper };\n');
+  const g = buildCallGraph(root, { srcDirs: ['src'] });
+  assert.ok(edgesOf(g, 'a.js#run').some((t) => t.includes('b.js#helper')), 'JS call edge must still resolve');
+  rm(root);
+});
+
+console.log('');
+console.log(`${passed} passed, ${failed} failed`);
+if (failed > 0) process.exit(1);

--- a/version.json
+++ b/version.json
@@ -5,7 +5,7 @@
   "languages": 33,
   "extractors": 43,
   "mcp_tools": 21,
-  "tests": 140,
+  "tests": 141,
   "metrics": {
     "hit_at_5": 0.811,
     "baseline_hit_at_5": 0.136,


### PR DESCRIPTION
Closes #562. W2–W3 of the revised plan; follows #561 (W1).

## Problem

`callsInRange` discarded every `receiver.method(` call as unresolvable. In Java that is essentially all inter-object calls — **1,461 of 2,516 call sites (58%)** in mall's portal module — so controller→service and service→mapper edges did not exist.

Three causes, all in `call-graph.js`, which has its own walk and did not share #560's fixes:

| | |
|---|---|
| `opts.srcDirs \|\| ['src','app','lib']` | default opts → **0 symbols, 0 edges** on any Maven module |
| `_walk`'s own `depth > 8` | `service/impl/` sits 9 dirs down — the classes owning the bodies were never scanned |
| `if (before === '.') continue` | 58% of call sites dropped |

## Change

**srcDirs and depth** now mirror #560: explicit opts → project config → historical defaults; depth is an option defaulting to 12.

**Receiver resolution.** A receiver→type map is built from field and local declarations, the type is mapped to its file by the JVM convention that a public type lives in a like-named file, and the method is looked up there. A receiver whose type cannot be determined still yields **no edge** — chained (`a.b().c()`) and computed (`arr[0].d()`) receivers are skipped rather than guessed.

**Interface declarations are indexed** as nodes with an empty body range. They emit no calls, but in Spring the declared interface is what callers name — without them, every controller→service edge had no target.

**Confidence** is `high` (typed receiver resolved in scope) or `medium` (type known, resolved by unique name outside scope), exposed as a separate map so `forward`/`reverse` keep their shape and no current consumer changes.

## Two regressions I caught and fixed mid-flight

Indexing declarations initially swallowed statements, breaking two existing Java tests:

- `identity(1);` — a call at line start — was read as a declaration. Fixed by requiring a non-empty head (modifiers or return type).
- `return helper(a);` — head `"return "` passed that check, creating a **phantom local def that captured the edge** instead of the real cross-file target. Fixed by rejecting statement keywords in the head.

The second is the more interesting one: it would have silently mis-attributed edges rather than losing them.

## Measured on macrozheng/mall (default opts)

| | before | after |
|---|---:|---:|
| symbols | 0 | **13,417** |
| edges | 0 | **10,213** (9,837 high / 376 medium) |
| `getCurrentMember` callers | 0 | **31** |
| `calcCartPromotion` callers | 0 | **1** |
| `OmsPortalOrderService#generateOrder` | 0 | **1** — the controller |

### One honest limitation

`methodImpact('generateOrder')` by **bare name** still reports 0. The controller method shares the name, so it becomes a seed and `_bfs` filters it out of its own result. That is pre-existing name-collision behaviour, not introduced here — the qualified symbol id resolves correctly, as the table shows.

## Tests

11 new cases in `test/integration/java-receiver-calls.test.js`. **8 of 11 fail against the pre-fix implementation**; the 3 that pass both ways are the regression guards — no-guessing on undeclared receivers, unchanged `forward`/`reverse` shape, and JS edges unaffected.

Full suite: **135 passed, 0 failed**. Bundle regenerated; `version.json` test count synced.

## Next

W4 — Spring `@Autowired` interface→impl resolution. This PR resolves the call to the *interface*, which is accurate; W4 adds the hop to the concrete `@Service`.