### PR TITLE
feat(graph): link Spring interface calls to their implementation

### DIFF
--- a/gen-context.js
+++ b/gen-context.js
@@ -12080,6 +12080,37 @@ __factories["./src/graph/call-graph"] = function(module, exports) {
     'if', 'while', 'for', 'switch', 'catch', 'synchronized', 'instanceof', 'await',
   ]);
 
+  // Types a Java class declares it implements or extends, with generic arguments
+  // stripped and any package qualifier dropped: `implements Foo<Bar, Baz>` yields
+  // ['Foo'], never 'Baz>'. Also records whether the class is a Spring bean and
+  // whether it is @Primary, which is what disambiguates several implementations.
+  function javaTypeDecl(masked) {
+    const m = /(?:^|\n)[^\n]*?\bclass\s+([A-Za-z_$][\w$]*)([^{]*)\{/.exec(masked);
+    if (!m) return null;
+    const [, className, tail] = m;
+    const supers = [];
+    for (const kw of ['implements', 'extends']) {
+      const k = new RegExp('\\b' + kw + '\\s+([^{]*?)(?=\\b(?:implements|extends)\\b|$)').exec(tail);
+      if (!k) continue;
+      let depth = 0;
+      let cur = '';
+      for (const ch of k[1]) {
+        if (ch === '<') { depth++; continue; }
+        if (ch === '>') { depth--; continue; }
+        if (ch === ',' && depth === 0) { if (cur.trim()) supers.push(cur.trim()); cur = ''; continue; }
+        if (depth === 0) cur += ch;
+      }
+      if (cur.trim()) supers.push(cur.trim());
+    }
+    const head = masked.slice(0, m.index + m[0].length);
+    return {
+      className,
+      supers: supers.map((t) => t.split('.').pop().trim()).filter(Boolean),
+      isBean: /@(Service|Component|Repository|Controller|RestController)\b/.test(head),
+      isPrimary: /@Primary\b/.test(head),
+    };
+  }
+
   function javaDefs(masked) {
     const defs = [];
     const seen = new Set();
@@ -12301,6 +12332,32 @@ __factories["./src/graph/call-graph"] = function(module, exports) {
       }
     }
 
+    // interface/superclass name → implementing files, for the Spring hop below.
+    const implsByType = new Map();     // 'PaymentService' → [{ file, isBean, isPrimary }]
+    for (const f of files) {
+      if (!JAVA_EXTS.has(path.extname(f).toLowerCase())) continue;
+      let decl;
+      try { decl = javaTypeDecl(maskJs(fs.readFileSync(f, 'utf8'))); } catch (_) { continue; }
+      if (!decl) continue;
+      for (const sup of decl.supers) {
+        if (!implsByType.has(sup)) implsByType.set(sup, []);
+        implsByType.get(sup).push({ file: f, isBean: decl.isBean, isPrimary: decl.isPrimary });
+      }
+    }
+
+    /**
+     * The single implementing file for a type, or null when it is ambiguous.
+     * One implementation resolves outright; several resolve only via @Primary.
+     * Anything still ambiguous yields no edge — polymorphism is not guessed.
+     */
+    const soleImpl = (typeName) => {
+      const cands = implsByType.get(typeName) || [];
+      if (cands.length === 1) return cands[0].file;
+      const primary = cands.filter((c) => c.isPrimary);
+      if (primary.length === 1) return primary[0].file;
+      return null;
+    };
+
     for (const f of files) {
       normToAbs.set(normalizePath(path.resolve(f)), path.resolve(f));
       let src;
@@ -12395,6 +12452,16 @@ __factories["./src/graph/call-graph"] = function(module, exports) {
           }
           const ids = (defsByName.get(target) || new Map()).get(method);
           if (ids && ids.length) for (const id of ids) addEdge(callerId, id, confidence);
+
+          // Spring: the call names the interface, but the code that runs — and
+          // that a reviewer changes — lives in the implementation. Both edges are
+          // true, so both are recorded; without the second, blast radius on an
+          // implementation is empty.
+          const implFile = soleImpl(typeName);
+          if (implFile && implFile !== target) {
+            const implIds = (defsByName.get(implFile) || new Map()).get(method);
+            if (implIds && implIds.length) for (const id of implIds) addEdge(callerId, id, confidence);
+          }
         }
       }
     }
@@ -12526,7 +12593,7 @@ __factories["./src/graph/call-graph"] = function(module, exports) {
   }
 
   module.exports = {
-    buildCallGraph, buildTypeMap, receiverCallsInRange, DEFAULT_WALK_DEPTH, buildCallFileGraph, methodImpact, methodCallees,
+    buildCallGraph, buildTypeMap, receiverCallsInRange, javaTypeDecl, DEFAULT_WALK_DEPTH, buildCallFileGraph, methodImpact, methodCallees,
     formatCallGraph, formatCallGraphJSON,
     extractDefs, maskJs, maskPy, maskRust,
   };

--- a/src/graph/call-graph.js
+++ b/src/graph/call-graph.js
@@ -255,6 +255,37 @@ const STMT_KEYWORDS = new Set([
   'if', 'while', 'for', 'switch', 'catch', 'synchronized', 'instanceof', 'await',
 ]);
 
+// Types a Java class declares it implements or extends, with generic arguments
+// stripped and any package qualifier dropped: `implements Foo<Bar, Baz>` yields
+// ['Foo'], never 'Baz>'. Also records whether the class is a Spring bean and
+// whether it is @Primary, which is what disambiguates several implementations.
+function javaTypeDecl(masked) {
+  const m = /(?:^|\n)[^\n]*?\bclass\s+([A-Za-z_$][\w$]*)([^{]*)\{/.exec(masked);
+  if (!m) return null;
+  const [, className, tail] = m;
+  const supers = [];
+  for (const kw of ['implements', 'extends']) {
+    const k = new RegExp('\\b' + kw + '\\s+([^{]*?)(?=\\b(?:implements|extends)\\b|$)').exec(tail);
+    if (!k) continue;
+    let depth = 0;
+    let cur = '';
+    for (const ch of k[1]) {
+      if (ch === '<') { depth++; continue; }
+      if (ch === '>') { depth--; continue; }
+      if (ch === ',' && depth === 0) { if (cur.trim()) supers.push(cur.trim()); cur = ''; continue; }
+      if (depth === 0) cur += ch;
+    }
+    if (cur.trim()) supers.push(cur.trim());
+  }
+  const head = masked.slice(0, m.index + m[0].length);
+  return {
+    className,
+    supers: supers.map((t) => t.split('.').pop().trim()).filter(Boolean),
+    isBean: /@(Service|Component|Repository|Controller|RestController)\b/.test(head),
+    isPrimary: /@Primary\b/.test(head),
+  };
+}
+
 function javaDefs(masked) {
   const defs = [];
   const seen = new Set();
@@ -476,6 +507,32 @@ function buildCallGraph(cwd, opts = {}) {
     }
   }
 
+  // interface/superclass name → implementing files, for the Spring hop below.
+  const implsByType = new Map();     // 'PaymentService' → [{ file, isBean, isPrimary }]
+  for (const f of files) {
+    if (!JAVA_EXTS.has(path.extname(f).toLowerCase())) continue;
+    let decl;
+    try { decl = javaTypeDecl(maskJs(fs.readFileSync(f, 'utf8'))); } catch (_) { continue; }
+    if (!decl) continue;
+    for (const sup of decl.supers) {
+      if (!implsByType.has(sup)) implsByType.set(sup, []);
+      implsByType.get(sup).push({ file: f, isBean: decl.isBean, isPrimary: decl.isPrimary });
+    }
+  }
+
+  /**
+   * The single implementing file for a type, or null when it is ambiguous.
+   * One implementation resolves outright; several resolve only via @Primary.
+   * Anything still ambiguous yields no edge — polymorphism is not guessed.
+   */
+  const soleImpl = (typeName) => {
+    const cands = implsByType.get(typeName) || [];
+    if (cands.length === 1) return cands[0].file;
+    const primary = cands.filter((c) => c.isPrimary);
+    if (primary.length === 1) return primary[0].file;
+    return null;
+  };
+
   for (const f of files) {
     normToAbs.set(normalizePath(path.resolve(f)), path.resolve(f));
     let src;
@@ -570,6 +627,16 @@ function buildCallGraph(cwd, opts = {}) {
         }
         const ids = (defsByName.get(target) || new Map()).get(method);
         if (ids && ids.length) for (const id of ids) addEdge(callerId, id, confidence);
+
+        // Spring: the call names the interface, but the code that runs — and
+        // that a reviewer changes — lives in the implementation. Both edges are
+        // true, so both are recorded; without the second, blast radius on an
+        // implementation is empty.
+        const implFile = soleImpl(typeName);
+        if (implFile && implFile !== target) {
+          const implIds = (defsByName.get(implFile) || new Map()).get(method);
+          if (implIds && implIds.length) for (const id of implIds) addEdge(callerId, id, confidence);
+        }
       }
     }
   }
@@ -701,7 +768,7 @@ function formatCallGraphJSON(result, kind) {
 }
 
 module.exports = {
-  buildCallGraph, buildTypeMap, receiverCallsInRange, DEFAULT_WALK_DEPTH, buildCallFileGraph, methodImpact, methodCallees,
+  buildCallGraph, buildTypeMap, receiverCallsInRange, javaTypeDecl, DEFAULT_WALK_DEPTH, buildCallFileGraph, methodImpact, methodCallees,
   formatCallGraph, formatCallGraphJSON,
   extractDefs, maskJs, maskPy, maskRust,
 };

--- a/test/integration/spring-interface-impl.test.js
+++ b/test/integration/spring-interface-impl.test.js
@@ -1,0 +1,151 @@
+'use strict';
+
+/**
+ * Spring interface → implementation resolution (#564).
+ *
+ * After #562 a Spring call site resolves to the interface method, which is what
+ * the source names. But blast radius on the class that owns the code was empty,
+ * so an implementation looked safe to change. These tests cover the added hop
+ * and, just as importantly, that ambiguous polymorphism is NOT guessed.
+ */
+
+const fs = require('fs');
+const os = require('os');
+const path = require('path');
+const assert = require('assert');
+
+const { buildCallGraph, javaTypeDecl, maskJs } = require('../../src/graph/call-graph');
+
+let passed = 0;
+let failed = 0;
+function test(name, fn) {
+  try { fn(); console.log(`  PASS  ${name}`); passed++; }
+  catch (e) { console.log(`  FAIL  ${name}\n        ${e.message}`); failed++; }
+}
+
+const tmp = () => fs.mkdtempSync(path.join(os.tmpdir(), 'sigmap-spring-'));
+const rm = (d) => fs.rmSync(d, { recursive: true, force: true });
+function write(root, rel, body) {
+  const abs = path.join(root, rel);
+  fs.mkdirSync(path.dirname(abs), { recursive: true });
+  fs.writeFileSync(abs, body);
+}
+const callersOf = (g, sub) => {
+  const id = [...g.defs.keys()].find((k) => k.includes(sub));
+  return id ? (g.reverse.get(id) || []) : null;
+};
+
+const BASE = 'app/src/main/java/com/example/app';
+
+/** Controller → interface, with `impls` implementations of that interface. */
+function springFixture(root, impls) {
+  write(root, `${BASE}/service/PaymentService.java`,
+    'package com.example.app.service;\npublic interface PaymentService {\n    void chargeCard(String id);\n}\n');
+  for (const { name, annotations = '@Service' } of impls) {
+    write(root, `${BASE}/service/impl/${name}.java`,
+      'package com.example.app.service.impl;\n' +
+      'import com.example.app.service.PaymentService;\n' +
+      `${annotations}\npublic class ${name} implements PaymentService {\n` +
+      '    public void chargeCard(String id) { }\n}\n');
+  }
+  write(root, `${BASE}/controller/PaymentController.java`,
+    'package com.example.app.controller;\n' +
+    'import com.example.app.service.PaymentService;\n' +
+    'public class PaymentController {\n' +
+    '    private PaymentService paymentService;\n' +
+    '    public void handleRequest() {\n        paymentService.chargeCard("x");\n    }\n}\n');
+  fs.writeFileSync(path.join(root, 'gen-context.config.json'), JSON.stringify({ srcDirs: ['app'] }));
+}
+
+// ---------------------------------------------------------------------------
+// Type declaration extraction
+// ---------------------------------------------------------------------------
+
+test('implements and extends are extracted', () => {
+  const d = javaTypeDecl(maskJs('public class P extends Base implements I, J {'));
+  assert.ok(d.supers.includes('I') && d.supers.includes('J') && d.supers.includes('Base'));
+});
+
+test('generic arguments are stripped, not mistaken for interfaces', () => {
+  const d = javaTypeDecl(maskJs('public class V implements ConstraintValidator<FlagValidator, Integer>, Other {'));
+  assert.deepStrictEqual(d.supers, ['ConstraintValidator', 'Other'],
+    `generic args must not leak into the list; got ${JSON.stringify(d.supers)}`);
+});
+
+test('a package-qualified supertype is reduced to its simple name', () => {
+  const d = javaTypeDecl(maskJs('public class A implements com.example.other.Thing {'));
+  assert.deepStrictEqual(d.supers, ['Thing']);
+});
+
+test('Spring bean and @Primary annotations are detected', () => {
+  assert.strictEqual(javaTypeDecl(maskJs('@Service\npublic class A implements I {')).isBean, true);
+  assert.strictEqual(javaTypeDecl(maskJs('@Primary\n@Service\npublic class A implements I {')).isPrimary, true);
+  assert.strictEqual(javaTypeDecl(maskJs('public class A implements I {')).isBean, false);
+});
+
+// ---------------------------------------------------------------------------
+// Resolution
+// ---------------------------------------------------------------------------
+
+test('a single implementation receives the caller', () => {
+  const root = tmp(); springFixture(root, [{ name: 'PaymentServiceImpl' }]);
+  const g = buildCallGraph(root);
+  const c = callersOf(g, 'PaymentServiceImpl.java#chargeCard');
+  assert.ok(c && c.length === 1, `impl must have the controller as a caller; got ${JSON.stringify(c)}`);
+  assert.ok(c[0].includes('PaymentController'), c[0]);
+  rm(root);
+});
+
+test('the interface edge from #562 is retained', () => {
+  const root = tmp(); springFixture(root, [{ name: 'PaymentServiceImpl' }]);
+  const g = buildCallGraph(root);
+  const c = callersOf(g, 'PaymentService.java#chargeCard');
+  assert.ok(c && c.length === 1, 'the source really does name the interface — that edge stays');
+  rm(root);
+});
+
+test('several implementations with no @Primary produce NO impl edge', () => {
+  const root = tmp();
+  springFixture(root, [{ name: 'CardPaymentImpl' }, { name: 'MockPaymentImpl' }]);
+  const g = buildCallGraph(root);
+  for (const n of ['CardPaymentImpl.java#chargeCard', 'MockPaymentImpl.java#chargeCard']) {
+    const c = callersOf(g, n);
+    assert.ok(!c || c.length === 0, `ambiguous polymorphism must not be guessed: ${n} got ${JSON.stringify(c)}`);
+  }
+  assert.ok(callersOf(g, 'PaymentService.java#chargeCard').length === 1, 'the interface edge still holds');
+  rm(root);
+});
+
+test('@Primary disambiguates several implementations', () => {
+  const root = tmp();
+  springFixture(root, [
+    { name: 'CardPaymentImpl', annotations: '@Primary\n@Service' },
+    { name: 'MockPaymentImpl' },
+  ]);
+  const g = buildCallGraph(root);
+  const primary = callersOf(g, 'CardPaymentImpl.java#chargeCard');
+  const other = callersOf(g, 'MockPaymentImpl.java#chargeCard');
+  assert.ok(primary && primary.length === 1, '@Primary must win');
+  assert.ok(!other || other.length === 0, 'the non-primary impl must not receive the edge');
+  rm(root);
+});
+
+test('resolved implementation edges carry a confidence label', () => {
+  const root = tmp(); springFixture(root, [{ name: 'PaymentServiceImpl' }]);
+  const g = buildCallGraph(root);
+  for (const v of g.edgeConfidence.values()) assert.ok(['high', 'medium'].includes(v), v);
+  rm(root);
+});
+
+test('JS behaviour is unchanged', () => {
+  const root = tmp();
+  write(root, 'src/a.js', "const { helper } = require('./b');\nfunction run() { helper(); }\n");
+  write(root, 'src/b.js', 'function helper() {}\nmodule.exports = { helper };\n');
+  const g = buildCallGraph(root, { srcDirs: ['src'] });
+  assert.ok(callersOf(g, 'b.js#helper').length === 1, 'JS edges must be unaffected');
+  rm(root);
+});
+
+console.log('');
+console.log(`${passed} passed, ${failed} failed`);
+if (failed > 0) process.exit(1);

--- a/version.json
+++ b/version.json
@@ -5,7 +5,7 @@
   "languages": 33,
   "extractors": 43,
   "mcp_tools": 21,
-  "tests": 141,
+  "tests": 142,
   "metrics": {
     "hit_at_5": 0.811,
     "baseline_hit_at_5": 0.136,


### PR DESCRIPTION
Closes #564. W4 of the revised plan.

> **Stacked on [#563](https://github.com/manojmallick/sigmap/pull/563)** — based on `fix/java-receiver-call-resolution-562`, not `develop`, because it builds directly on that receiver resolution. Retarget to `develop` once #563 merges.

## Problem

After #562 a Spring call site resolves to the **interface** method — correct, since that is what the source names. But blast radius on the class that owns the code was empty:

```
OmsPortalOrderService.java#generateOrder       callers: 1   (the controller)
OmsPortalOrderServiceImpl.java#generateOrder   callers: 0
```

So `--callers`, `get_method_impact` and any risk scoring reported an implementation as safe to change when it was not.

## Change

Java class declarations now yield their implemented interfaces and superclasses, plus whether the class is a Spring bean and whether it is `@Primary`. A receiver resolving to an interface method also links the caller to the implementing method.

**Generic arguments are stripped properly** — `implements ConstraintValidator<FlagValidator, Integer>, Other` yields `['ConstraintValidator', 'Other']`, never `'Integer>'`. A naive split on commas produces exactly that bug, and there is a test for it.

## Ambiguity is not guessed

| Case | Result |
|---|---|
| exactly one implementation | edge to the impl, `high` |
| several, one `@Primary` | edge to the primary, `high` |
| several, no `@Primary` | **no impl edge** — interface edge alone stands |

On mall this is the dominant case: **54 of 59 interfaces (92%) have exactly one implementation.**

The interface edge from #562 is retained. Both facts are true — the source names the interface, the implementation owns the code — so both are recorded rather than one being chosen.

## Measured on macrozheng/mall

| | #562 | this PR |
|---|---:|---:|
| edges | 10,213 | **10,492** |
| `OmsPortalOrderServiceImpl#generateOrder` callers | 0 | **1** (the controller) |

## Tests

10 new cases in `test/integration/spring-interface-impl.test.js`: extends/implements extraction, generic stripping, package-qualified supertypes, bean and `@Primary` detection, single-impl resolution, interface-edge retention, **no edge when ambiguous**, `@Primary` disambiguation, confidence labels, and JS unaffected.

**6 of 10 fail against the #562 baseline**; the 4 that pass both ways are the retention guards — the interface edge, the no-guessing rule, confidence labels, and JS behaviour.

Full suite: **136 passed, 0 failed**.

One flake worth noting: `coverage-score.test.js` hit `spawnSync ETIMEDOUT` under full-suite load, as it did in #561. It passes in isolation both times. That test is load-sensitive and unrelated to this work.