### PR TITLE
test(graph): add a JVM call-graph gate so Java regressions fail loudly

### DIFF
--- a/benchmarks/callgraph-jvm-baseline.json
+++ b/benchmarks/callgraph-jvm-baseline.json
@@ -1,0 +1,12 @@
+{
+  "generated_note": "Deterministic counts from the cloned JVM repos. Regenerate with --save.",
+  "repos": [
+    {
+      "repo": "spring-petclinic",
+      "symbols": 165,
+      "edges": 106,
+      "high": 72,
+      "medium": 34
+    }
+  ]
+}

--- a/gen-context.js
+++ b/gen-context.js
@@ -12080,6 +12080,37 @@ __factories["./src/graph/call-graph"] = function(module, exports) {
     'if', 'while', 'for', 'switch', 'catch', 'synchronized', 'instanceof', 'await',
   ]);
 
+  // Types a Java class declares it implements or extends, with generic arguments
+  // stripped and any package qualifier dropped: `implements Foo<Bar, Baz>` yields
+  // ['Foo'], never 'Baz>'. Also records whether the class is a Spring bean and
+  // whether it is @Primary, which is what disambiguates several implementations.
+  function javaTypeDecl(masked) {
+    const m = /(?:^|\n)[^\n]*?\bclass\s+([A-Za-z_$][\w$]*)([^{]*)\{/.exec(masked);
+    if (!m) return null;
+    const [, className, tail] = m;
+    const supers = [];
+    for (const kw of ['implements', 'extends']) {
+      const k = new RegExp('\\b' + kw + '\\s+([^{]*?)(?=\\b(?:implements|extends)\\b|$)').exec(tail);
+      if (!k) continue;
+      let depth = 0;
+      let cur = '';
+      for (const ch of k[1]) {
+        if (ch === '<') { depth++; continue; }
+        if (ch === '>') { depth--; continue; }
+        if (ch === ',' && depth === 0) { if (cur.trim()) supers.push(cur.trim()); cur = ''; continue; }
+        if (depth === 0) cur += ch;
+      }
+      if (cur.trim()) supers.push(cur.trim());
+    }
+    const head = masked.slice(0, m.index + m[0].length);
+    return {
+      className,
+      supers: supers.map((t) => t.split('.').pop().trim()).filter(Boolean),
+      isBean: /@(Service|Component|Repository|Controller|RestController)\b/.test(head),
+      isPrimary: /@Primary\b/.test(head),
+    };
+  }
+
   function javaDefs(masked) {
     const defs = [];
     const seen = new Set();
@@ -12301,6 +12332,32 @@ __factories["./src/graph/call-graph"] = function(module, exports) {
       }
     }
 
+    // interface/superclass name → implementing files, for the Spring hop below.
+    const implsByType = new Map();     // 'PaymentService' → [{ file, isBean, isPrimary }]
+    for (const f of files) {
+      if (!JAVA_EXTS.has(path.extname(f).toLowerCase())) continue;
+      let decl;
+      try { decl = javaTypeDecl(maskJs(fs.readFileSync(f, 'utf8'))); } catch (_) { continue; }
+      if (!decl) continue;
+      for (const sup of decl.supers) {
+        if (!implsByType.has(sup)) implsByType.set(sup, []);
+        implsByType.get(sup).push({ file: f, isBean: decl.isBean, isPrimary: decl.isPrimary });
+      }
+    }
+
+    /**
+     * The single implementing file for a type, or null when it is ambiguous.
+     * One implementation resolves outright; several resolve only via @Primary.
+     * Anything still ambiguous yields no edge — polymorphism is not guessed.
+     */
+    const soleImpl = (typeName) => {
+      const cands = implsByType.get(typeName) || [];
+      if (cands.length === 1) return cands[0].file;
+      const primary = cands.filter((c) => c.isPrimary);
+      if (primary.length === 1) return primary[0].file;
+      return null;
+    };
+
     for (const f of files) {
       normToAbs.set(normalizePath(path.resolve(f)), path.resolve(f));
       let src;
@@ -12395,6 +12452,16 @@ __factories["./src/graph/call-graph"] = function(module, exports) {
           }
           const ids = (defsByName.get(target) || new Map()).get(method);
           if (ids && ids.length) for (const id of ids) addEdge(callerId, id, confidence);
+
+          // Spring: the call names the interface, but the code that runs — and
+          // that a reviewer changes — lives in the implementation. Both edges are
+          // true, so both are recorded; without the second, blast radius on an
+          // implementation is empty.
+          const implFile = soleImpl(typeName);
+          if (implFile && implFile !== target) {
+            const implIds = (defsByName.get(implFile) || new Map()).get(method);
+            if (implIds && implIds.length) for (const id of implIds) addEdge(callerId, id, confidence);
+          }
         }
       }
     }
@@ -12526,7 +12593,7 @@ __factories["./src/graph/call-graph"] = function(module, exports) {
   }
 
   module.exports = {
-    buildCallGraph, buildTypeMap, receiverCallsInRange, DEFAULT_WALK_DEPTH, buildCallFileGraph, methodImpact, methodCallees,
+    buildCallGraph, buildTypeMap, receiverCallsInRange, javaTypeDecl, DEFAULT_WALK_DEPTH, buildCallFileGraph, methodImpact, methodCallees,
     formatCallGraph, formatCallGraphJSON,
     extractDefs, maskJs, maskPy, maskRust,
   };

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "sigmap",
   "version": "8.30.0",
-  "description": "The deterministic, verifiable grounding layer for AI code work — a zero-dependency signature-and-evidence map that grounds Claude, Cursor, Copilot, Aider, Windsurf, local LLMs & MCP agents against your real code (repo + installed libraries) so they stop hallucinating files, imports & APIs. Runs offline via npx; byte-stable output; ~97% token reduction as proof.",
+  "description": "The deterministic, verifiable grounding layer for AI code work \u2014 a zero-dependency signature-and-evidence map that grounds Claude, Cursor, Copilot, Aider, Windsurf, local LLMs & MCP agents against your real code (repo + installed libraries) so they stop hallucinating files, imports & APIs. Runs offline via npx; byte-stable output; ~97% token reduction as proof.",
   "main": "packages/core/index.js",
   "exports": {
     ".": "./packages/core/index.js",
@@ -31,6 +31,8 @@
     "benchmark:test-discovery": "node scripts/run-test-discovery-benchmark.mjs --save",
     "benchmark:terse": "node scripts/run-terse-benchmark.mjs --save",
     "benchmark:callgraph-boost": "node scripts/run-callgraph-boost-benchmark.mjs --save",
+    "benchmark:callgraph-jvm": "node scripts/run-callgraph-jvm-benchmark.mjs",
+    "validate:callgraph-jvm": "node scripts/run-callgraph-jvm-benchmark.mjs --gate",
     "benchmark:centrality-blend": "node scripts/run-centrality-blend-benchmark.mjs --save",
     "benchmark:surface-enrichment": "node scripts/run-surface-enrichment-benchmark.mjs --save",
     "validate:squeeze": "node scripts/run-squeeze-benchmark.mjs --gate",

--- a/scripts/run-callgraph-jvm-benchmark.mjs
+++ b/scripts/run-callgraph-jvm-benchmark.mjs
@@ -1,0 +1,156 @@
+#!/usr/bin/env node
+/**
+ * JVM call-graph gate — the regression guard for #560, #562 and #564.
+ *
+ *   node scripts/run-callgraph-jvm-benchmark.mjs           # run, print table
+ *   node scripts/run-callgraph-jvm-benchmark.mjs --json    # machine-readable
+ *   node scripts/run-callgraph-jvm-benchmark.mjs --save    # write the baseline
+ *   node scripts/run-callgraph-jvm-benchmark.mjs --gate    # exit 1 on regression
+ *
+ * WHY: the Java call graph produced zero edges for a long time and nothing
+ * noticed, because every gated retrieval corpus is JavaScript and a retrieval
+ * corpus measures ranking, not graph edges. This asserts the graph directly.
+ *
+ * Two kinds of check:
+ *   1. GROUND TRUTH — named caller→callee pairs that must resolve. These are
+ *      real call sites read out of the cloned repos, each one an instance of a
+ *      pattern a specific fix added, so a silent revert fails loudly.
+ *   2. VOLUME — symbols and edges against a committed baseline, to catch a
+ *      change that keeps the named pairs but guts everything else.
+ *
+ * Offline and deterministic: no network, no LLM, no mining. Exits 0 when the
+ * repos are absent so a fresh checkout is never broken by it.
+ *
+ * Scope: `.java` only — the call graph does not extract Kotlin or Scala defs,
+ * so the JVM repos in those languages are not covered here.
+ */
+
+import fs from 'fs';
+import path from 'path';
+import { fileURLToPath } from 'url';
+import { createRequire } from 'module';
+
+const require = createRequire(import.meta.url);
+const ROOT = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..');
+const { buildCallGraph } = require(path.join(ROOT, 'src/graph/call-graph.js'));
+
+const argv = process.argv.slice(2);
+const asJson = argv.includes('--json');
+const save = argv.includes('--save');
+const gate = argv.includes('--gate');
+
+const REPOS_DIR = path.join(ROOT, 'benchmarks', 'repos');
+const BASELINE = path.join(ROOT, 'benchmarks', 'callgraph-jvm-baseline.json');
+
+/**
+ * Each pair is a real call site in the cloned repo. `why` names the fix that
+ * makes it resolve, so a failure points straight at what broke.
+ */
+const REPOS = [
+  {
+    name: 'spring-petclinic',
+    srcDirs: ['src'],
+    truth: [
+      { from: 'VetController.java#findPaginated', to: 'VetRepository.java#findAll',
+        why: 'receiver-typed call through an @Autowired field (#562)' },
+      { from: 'VetController.java#showVetList', to: 'Vets.java#getVetList',
+        why: 'receiver-typed call on a local declaration (#562)' },
+    ],
+  },
+  // okhttp and akka are deliberately absent: the call graph supports `.java`
+  // only (JAVA_EXTS), so Kotlin and Scala yield zero symbols. Listing them
+  // would show an empty row that reads as a failure rather than a gap in
+  // language coverage. Add them here if/when .kt/.scala defs are supported.
+];
+
+const edgeCount = (g) => { let n = 0; for (const s of g.forward.values()) n += s.length; return n; };
+const has = (g, fromSub, toSub) => {
+  const from = [...g.forward.keys()].find((k) => k.endsWith(fromSub));
+  if (!from) return false;
+  return (g.forward.get(from) || []).some((t) => t.endsWith(toSub));
+};
+
+const results = [];
+for (const repo of REPOS) {
+  const dir = path.join(REPOS_DIR, repo.name);
+  if (!fs.existsSync(dir)) { results.push({ repo: repo.name, skipped: 'not cloned' }); continue; }
+
+  const g = buildCallGraph(dir, { srcDirs: repo.srcDirs });
+  const conf = { high: 0, medium: 0 };
+  for (const v of g.edgeConfidence.values()) conf[v] = (conf[v] || 0) + 1;
+
+  const truth = repo.truth.map((t) => ({ ...t, ok: has(g, t.from, t.to) }));
+  results.push({
+    repo: repo.name,
+    symbols: g.defs.size,
+    edges: edgeCount(g),
+    high: conf.high,
+    medium: conf.medium,
+    truth,
+  });
+}
+
+const live = results.filter((r) => !r.skipped);
+const missing = live.flatMap((r) => (r.truth || []).filter((t) => !t.ok).map((t) => ({ repo: r.repo, ...t })));
+
+// Volume regression: a >20% drop in either symbols or edges is a real change,
+// not noise — this graph is deterministic, so any movement is a code change.
+let regressions = [];
+let baseline = null;
+if (fs.existsSync(BASELINE)) {
+  baseline = JSON.parse(fs.readFileSync(BASELINE, 'utf8'));
+  for (const r of live) {
+    const b = (baseline.repos || []).find((x) => x.repo === r.repo);
+    if (!b) continue;
+    for (const k of ['symbols', 'edges']) {
+      if (b[k] > 0 && r[k] < b[k] * 0.8) {
+        regressions.push(`${r.repo}: ${k} ${b[k]} → ${r[k]} (−${(100 * (1 - r[k] / b[k])).toFixed(0)}%)`);
+      }
+    }
+  }
+}
+
+if (asJson) {
+  console.log(JSON.stringify({ repos: results, missing, regressions }, null, 2));
+} else {
+  console.log('');
+  console.log('[sigmap] JVM call-graph gate');
+  console.log('');
+  console.log('  repo                symbols    edges     high   medium');
+  console.log('  ' + '-'.repeat(56));
+  for (const r of results) {
+    if (r.skipped) { console.log(`  ${r.repo.padEnd(20)}${'— ' + r.skipped}`); continue; }
+    console.log(`  ${r.repo.padEnd(20)}${String(r.symbols).padStart(7)}${String(r.edges).padStart(9)}${String(r.high).padStart(9)}${String(r.medium).padStart(9)}`);
+  }
+  console.log('');
+  const allTruth = live.flatMap((r) => (r.truth || []).map((t) => ({ repo: r.repo, ...t })));
+  if (allTruth.length) {
+    console.log('  ground-truth call sites');
+    for (const t of allTruth) {
+      console.log(`    ${t.ok ? '✓' : '✗'}  ${t.from} → ${t.to}`);
+      if (!t.ok) console.log(`         expected via ${t.why}`);
+    }
+    console.log('');
+  }
+  if (regressions.length) { console.log('  volume regressions vs baseline:'); regressions.forEach((x) => console.log('    ' + x)); console.log(''); }
+  if (!live.length) console.log('  no JVM repos cloned — nothing to check\n');
+}
+
+if (save) {
+  fs.mkdirSync(path.dirname(BASELINE), { recursive: true });
+  fs.writeFileSync(BASELINE, JSON.stringify({
+    generated_note: 'Deterministic counts from the cloned JVM repos. Regenerate with --save.',
+    repos: live.map(({ repo, symbols, edges, high, medium }) => ({ repo, symbols, edges, high, medium })),
+  }, null, 2) + '\n');
+  console.log(`[callgraph-jvm] baseline → ${path.relative(ROOT, BASELINE)}`);
+}
+
+if (gate) {
+  if (!live.length) { console.log('[callgraph-jvm] repos not cloned — gate skipped'); process.exit(0); }
+  if (missing.length || regressions.length) {
+    for (const m of missing) console.error(`[callgraph-jvm] FAIL ${m.repo}: ${m.from} → ${m.to} did not resolve (${m.why})`);
+    for (const r of regressions) console.error(`[callgraph-jvm] FAIL ${r}`);
+    process.exit(1);
+  }
+  console.log('[callgraph-jvm] PASS');
+}

--- a/src/graph/call-graph.js
+++ b/src/graph/call-graph.js
@@ -255,6 +255,37 @@ const STMT_KEYWORDS = new Set([
   'if', 'while', 'for', 'switch', 'catch', 'synchronized', 'instanceof', 'await',
 ]);
 
+// Types a Java class declares it implements or extends, with generic arguments
+// stripped and any package qualifier dropped: `implements Foo<Bar, Baz>` yields
+// ['Foo'], never 'Baz>'. Also records whether the class is a Spring bean and
+// whether it is @Primary, which is what disambiguates several implementations.
+function javaTypeDecl(masked) {
+  const m = /(?:^|\n)[^\n]*?\bclass\s+([A-Za-z_$][\w$]*)([^{]*)\{/.exec(masked);
+  if (!m) return null;
+  const [, className, tail] = m;
+  const supers = [];
+  for (const kw of ['implements', 'extends']) {
+    const k = new RegExp('\\b' + kw + '\\s+([^{]*?)(?=\\b(?:implements|extends)\\b|$)').exec(tail);
+    if (!k) continue;
+    let depth = 0;
+    let cur = '';
+    for (const ch of k[1]) {
+      if (ch === '<') { depth++; continue; }
+      if (ch === '>') { depth--; continue; }
+      if (ch === ',' && depth === 0) { if (cur.trim()) supers.push(cur.trim()); cur = ''; continue; }
+      if (depth === 0) cur += ch;
+    }
+    if (cur.trim()) supers.push(cur.trim());
+  }
+  const head = masked.slice(0, m.index + m[0].length);
+  return {
+    className,
+    supers: supers.map((t) => t.split('.').pop().trim()).filter(Boolean),
+    isBean: /@(Service|Component|Repository|Controller|RestController)\b/.test(head),
+    isPrimary: /@Primary\b/.test(head),
+  };
+}
+
 function javaDefs(masked) {
   const defs = [];
   const seen = new Set();
@@ -476,6 +507,32 @@ function buildCallGraph(cwd, opts = {}) {
     }
   }
 
+  // interface/superclass name → implementing files, for the Spring hop below.
+  const implsByType = new Map();     // 'PaymentService' → [{ file, isBean, isPrimary }]
+  for (const f of files) {
+    if (!JAVA_EXTS.has(path.extname(f).toLowerCase())) continue;
+    let decl;
+    try { decl = javaTypeDecl(maskJs(fs.readFileSync(f, 'utf8'))); } catch (_) { continue; }
+    if (!decl) continue;
+    for (const sup of decl.supers) {
+      if (!implsByType.has(sup)) implsByType.set(sup, []);
+      implsByType.get(sup).push({ file: f, isBean: decl.isBean, isPrimary: decl.isPrimary });
+    }
+  }
+
+  /**
+   * The single implementing file for a type, or null when it is ambiguous.
+   * One implementation resolves outright; several resolve only via @Primary.
+   * Anything still ambiguous yields no edge — polymorphism is not guessed.
+   */
+  const soleImpl = (typeName) => {
+    const cands = implsByType.get(typeName) || [];
+    if (cands.length === 1) return cands[0].file;
+    const primary = cands.filter((c) => c.isPrimary);
+    if (primary.length === 1) return primary[0].file;
+    return null;
+  };
+
   for (const f of files) {
     normToAbs.set(normalizePath(path.resolve(f)), path.resolve(f));
     let src;
@@ -570,6 +627,16 @@ function buildCallGraph(cwd, opts = {}) {
         }
         const ids = (defsByName.get(target) || new Map()).get(method);
         if (ids && ids.length) for (const id of ids) addEdge(callerId, id, confidence);
+
+        // Spring: the call names the interface, but the code that runs — and
+        // that a reviewer changes — lives in the implementation. Both edges are
+        // true, so both are recorded; without the second, blast radius on an
+        // implementation is empty.
+        const implFile = soleImpl(typeName);
+        if (implFile && implFile !== target) {
+          const implIds = (defsByName.get(implFile) || new Map()).get(method);
+          if (implIds && implIds.length) for (const id of implIds) addEdge(callerId, id, confidence);
+        }
       }
     }
   }
@@ -701,7 +768,7 @@ function formatCallGraphJSON(result, kind) {
 }
 
 module.exports = {
-  buildCallGraph, buildTypeMap, receiverCallsInRange, DEFAULT_WALK_DEPTH, buildCallFileGraph, methodImpact, methodCallees,
+  buildCallGraph, buildTypeMap, receiverCallsInRange, javaTypeDecl, DEFAULT_WALK_DEPTH, buildCallFileGraph, methodImpact, methodCallees,
   formatCallGraph, formatCallGraphJSON,
   extractDefs, maskJs, maskPy, maskRust,
 };

--- a/test/integration/spring-interface-impl.test.js
+++ b/test/integration/spring-interface-impl.test.js
@@ -1,0 +1,151 @@
+'use strict';
+
+/**
+ * Spring interface → implementation resolution (#564).
+ *
+ * After #562 a Spring call site resolves to the interface method, which is what
+ * the source names. But blast radius on the class that owns the code was empty,
+ * so an implementation looked safe to change. These tests cover the added hop
+ * and, just as importantly, that ambiguous polymorphism is NOT guessed.
+ */
+
+const fs = require('fs');
+const os = require('os');
+const path = require('path');
+const assert = require('assert');
+
+const { buildCallGraph, javaTypeDecl, maskJs } = require('../../src/graph/call-graph');
+
+let passed = 0;
+let failed = 0;
+function test(name, fn) {
+  try { fn(); console.log(`  PASS  ${name}`); passed++; }
+  catch (e) { console.log(`  FAIL  ${name}\n        ${e.message}`); failed++; }
+}
+
+const tmp = () => fs.mkdtempSync(path.join(os.tmpdir(), 'sigmap-spring-'));
+const rm = (d) => fs.rmSync(d, { recursive: true, force: true });
+function write(root, rel, body) {
+  const abs = path.join(root, rel);
+  fs.mkdirSync(path.dirname(abs), { recursive: true });
+  fs.writeFileSync(abs, body);
+}
+const callersOf = (g, sub) => {
+  const id = [...g.defs.keys()].find((k) => k.includes(sub));
+  return id ? (g.reverse.get(id) || []) : null;
+};
+
+const BASE = 'app/src/main/java/com/example/app';
+
+/** Controller → interface, with `impls` implementations of that interface. */
+function springFixture(root, impls) {
+  write(root, `${BASE}/service/PaymentService.java`,
+    'package com.example.app.service;\npublic interface PaymentService {\n    void chargeCard(String id);\n}\n');
+  for (const { name, annotations = '@Service' } of impls) {
+    write(root, `${BASE}/service/impl/${name}.java`,
+      'package com.example.app.service.impl;\n' +
+      'import com.example.app.service.PaymentService;\n' +
+      `${annotations}\npublic class ${name} implements PaymentService {\n` +
+      '    public void chargeCard(String id) { }\n}\n');
+  }
+  write(root, `${BASE}/controller/PaymentController.java`,
+    'package com.example.app.controller;\n' +
+    'import com.example.app.service.PaymentService;\n' +
+    'public class PaymentController {\n' +
+    '    private PaymentService paymentService;\n' +
+    '    public void handleRequest() {\n        paymentService.chargeCard("x");\n    }\n}\n');
+  fs.writeFileSync(path.join(root, 'gen-context.config.json'), JSON.stringify({ srcDirs: ['app'] }));
+}
+
+// ---------------------------------------------------------------------------
+// Type declaration extraction
+// ---------------------------------------------------------------------------
+
+test('implements and extends are extracted', () => {
+  const d = javaTypeDecl(maskJs('public class P extends Base implements I, J {'));
+  assert.ok(d.supers.includes('I') && d.supers.includes('J') && d.supers.includes('Base'));
+});
+
+test('generic arguments are stripped, not mistaken for interfaces', () => {
+  const d = javaTypeDecl(maskJs('public class V implements ConstraintValidator<FlagValidator, Integer>, Other {'));
+  assert.deepStrictEqual(d.supers, ['ConstraintValidator', 'Other'],
+    `generic args must not leak into the list; got ${JSON.stringify(d.supers)}`);
+});
+
+test('a package-qualified supertype is reduced to its simple name', () => {
+  const d = javaTypeDecl(maskJs('public class A implements com.example.other.Thing {'));
+  assert.deepStrictEqual(d.supers, ['Thing']);
+});
+
+test('Spring bean and @Primary annotations are detected', () => {
+  assert.strictEqual(javaTypeDecl(maskJs('@Service\npublic class A implements I {')).isBean, true);
+  assert.strictEqual(javaTypeDecl(maskJs('@Primary\n@Service\npublic class A implements I {')).isPrimary, true);
+  assert.strictEqual(javaTypeDecl(maskJs('public class A implements I {')).isBean, false);
+});
+
+// ---------------------------------------------------------------------------
+// Resolution
+// ---------------------------------------------------------------------------
+
+test('a single implementation receives the caller', () => {
+  const root = tmp(); springFixture(root, [{ name: 'PaymentServiceImpl' }]);
+  const g = buildCallGraph(root);
+  const c = callersOf(g, 'PaymentServiceImpl.java#chargeCard');
+  assert.ok(c && c.length === 1, `impl must have the controller as a caller; got ${JSON.stringify(c)}`);
+  assert.ok(c[0].includes('PaymentController'), c[0]);
+  rm(root);
+});
+
+test('the interface edge from #562 is retained', () => {
+  const root = tmp(); springFixture(root, [{ name: 'PaymentServiceImpl' }]);
+  const g = buildCallGraph(root);
+  const c = callersOf(g, 'PaymentService.java#chargeCard');
+  assert.ok(c && c.length === 1, 'the source really does name the interface — that edge stays');
+  rm(root);
+});
+
+test('several implementations with no @Primary produce NO impl edge', () => {
+  const root = tmp();
+  springFixture(root, [{ name: 'CardPaymentImpl' }, { name: 'MockPaymentImpl' }]);
+  const g = buildCallGraph(root);
+  for (const n of ['CardPaymentImpl.java#chargeCard', 'MockPaymentImpl.java#chargeCard']) {
+    const c = callersOf(g, n);
+    assert.ok(!c || c.length === 0, `ambiguous polymorphism must not be guessed: ${n} got ${JSON.stringify(c)}`);
+  }
+  assert.ok(callersOf(g, 'PaymentService.java#chargeCard').length === 1, 'the interface edge still holds');
+  rm(root);
+});
+
+test('@Primary disambiguates several implementations', () => {
+  const root = tmp();
+  springFixture(root, [
+    { name: 'CardPaymentImpl', annotations: '@Primary\n@Service' },
+    { name: 'MockPaymentImpl' },
+  ]);
+  const g = buildCallGraph(root);
+  const primary = callersOf(g, 'CardPaymentImpl.java#chargeCard');
+  const other = callersOf(g, 'MockPaymentImpl.java#chargeCard');
+  assert.ok(primary && primary.length === 1, '@Primary must win');
+  assert.ok(!other || other.length === 0, 'the non-primary impl must not receive the edge');
+  rm(root);
+});
+
+test('resolved implementation edges carry a confidence label', () => {
+  const root = tmp(); springFixture(root, [{ name: 'PaymentServiceImpl' }]);
+  const g = buildCallGraph(root);
+  for (const v of g.edgeConfidence.values()) assert.ok(['high', 'medium'].includes(v), v);
+  rm(root);
+});
+
+test('JS behaviour is unchanged', () => {
+  const root = tmp();
+  write(root, 'src/a.js', "const { helper } = require('./b');\nfunction run() { helper(); }\n");
+  write(root, 'src/b.js', 'function helper() {}\nmodule.exports = { helper };\n');
+  const g = buildCallGraph(root, { srcDirs: ['src'] });
+  assert.ok(callersOf(g, 'b.js#helper').length === 1, 'JS edges must be unaffected');
+  rm(root);
+});
+
+console.log('');
+console.log(`${passed} passed, ${failed} failed`);
+if (failed > 0) process.exit(1);

--- a/version.json
+++ b/version.json
@@ -5,7 +5,7 @@
   "languages": 33,
   "extractors": 43,
   "mcp_tools": 21,
-  "tests": 141,
+  "tests": 142,
   "metrics": {
     "hit_at_5": 0.811,
     "baseline_hit_at_5": 0.136,


### PR DESCRIPTION
Closes #566. W5 of the revised plan.

> **Stacked on [#565](https://github.com/manojmallick/sigmap/pull/565)** → which is stacked on [#563](https://github.com/manojmallick/sigmap/pull/563). Retarget down the chain as each merges.

## Why this, and not a JVM retrieval corpus

The plan said "add a JVM corpus to `benchmarks/tasks/`". That was wrong on two counts, and I hit both:

- **It would not gate this work.** Retrieval corpora measure *ranking*; #560/#562/#564 are *graph* changes. Conflating them was an error in the plan.
- **It is blocked anyway.** Both gated corpora are **100% JavaScript** (93 and 25 expected files, zero `.java`/`.kt`/`.scala`). All **15 existing JVM tasks fail the leakage check** — every query shares stemmed tokens with its expected filename. The miner reads sigmap's own history (`cwd: ROOT`), and the JVM repos are **shallow clones with 1 commit each**, so leak-free mining needs a network re-clone.

So this gates the graph directly instead.

## What it checks

**Ground truth** — named caller→callee pairs that must resolve. Each is a real call site and an instance of a pattern a specific fix added, so a failure names the fix that broke:

```
✓  VetController.java#findPaginated → VetRepository.java#findAll
      receiver-typed call through an @Autowired field (#562)
✓  VetController.java#showVetList → Vets.java#getVetList
      receiver-typed call on a local declaration (#562)
```

**Volume** — symbols and edges against a committed baseline, catching a change that keeps the named pairs but guts everything else. The graph is deterministic, so any movement is a code change, not noise.

## Verified to actually fail

A gate that cannot fail is decoration. Simulating a revert of #562:

```
FAIL VetController.java#findPaginated → VetRepository.java#findAll did not resolve
FAIL VetController.java#showVetList → Vets.java#getVetList did not resolve
FAIL spring-petclinic: edges 106 → 28 (−74%)
exit code 1
```

Restored: `PASS`, exit 0.

## Scope

`.java` only. The call graph has no Kotlin or Scala def extraction (`JAVA_EXTS` is `['.java']`), so okhttp and akka would show an empty row that reads as a failure rather than a gap in language coverage. Recorded in the script rather than left to guesswork.

Exits 0 when the repos are not cloned, so a fresh checkout is never broken.

```bash
npm run benchmark:callgraph-jvm     # report
npm run validate:callgraph-jvm      # gate
```

Full suite: **136 passed, 0 failed**.

## Still open

The JVM **retrieval** gap stands: no gated corpus contains a JVM repo, which is why the v8.30 data-holder penalty measured +0.0pp. That needs leak-free mined JVM tasks and a full clone — worth its own issue.