### PR TITLE
docs(cli): fix the sigmap lines example breaking the VitePress build

### DIFF
--- a/docs-vp/guide/cli.md
+++ b/docs-vp/guide/cli.md
@@ -1300,16 +1300,16 @@ sigmap lines src/graph/builder.js :447         # a window around one line
 sigmap lines src/graph/builder.js :447 --context 20
 ```
 
-```text
+````text
 $ sigmap lines src/graph/builder.js :447 --context 2
 # src/graph/builder.js:445-449
 ```
- * @returns {{ forward: Map<string,string[]>, reverse: Map<string,string[]> }}
+ * @returns { forward: Map<string,string[]>, reverse: Map<string,string[]> }
  */
 function buildFromCwd(cwd, opts) {
   // R-package layouts use `R/` and `inst/`; Shiny apps put helpers in `R/`.
 ```
-```
+````
 
 The `:447` form takes an anchor **pasted straight off a signature** — `ask` prints `buildFromCwd(cwd, opts) → { forward: …  :447-501`, and that string is the argument.
 


### PR DESCRIPTION
Hotfix for the v8.31.0 Pages deploy, which failed twice.

## What broke

`sigmap lines` output is itself a fenced code block, and the example I added in `cli.md` nested it inside a three-backtick ```text fence. The inner fence closed the block early, leaving the JSDoc line as raw markdown — Vue then parsed `{{ forward: … }}` as an interpolation:

```
[vite:vue] guide/cli.md (1789:17): Error parsing JavaScript expression
```

Not the usual transient Pages failure: it failed on the push **and** on a fresh `workflow_dispatch`, because it is a genuine build error.

## Fix

Outer fence widened to four backticks so the inner one is literal, and the doubled braces dropped from the quoted line.

Verified with `npm run docs:build` in `docs-vp` — **build complete**, which is the check that would have caught this before the tag.

## Not affected

The release itself is fine and already out: **npm `sigmap@8.31.0` published**, 4 binaries attached, tag `v8.31.0` on `379e9c7`. Only the docs site build was broken.