### PR TITLE
refactor(extractors): one source of truth for extractor resolution

### DIFF
--- a/gen-context.js
+++ b/gen-context.js
@@ -4151,47 +4151,13 @@ __factories["./src/eval/analyzer"] = function(module, exports) {
   const path = require('path');
 
   // Extension → extractor name (mirrors EXT_MAP in gen-context.js)
-  const EXT_MAP = {
-    '.ts': 'typescript', '.tsx': 'typescript',
-    '.js': 'javascript', '.jsx': 'javascript', '.mjs': 'javascript', '.cjs': 'javascript',
-    '.py': 'python',     '.pyw': 'python',
-    '.java': 'java',
-    '.kt': 'kotlin',     '.kts': 'kotlin',
-    '.go': 'go',
-    '.rs': 'rust',
-    '.cs': 'csharp',
-    '.cpp': 'cpp', '.c': 'cpp', '.h': 'cpp', '.hpp': 'cpp', '.cc': 'cpp',
-    '.rb': 'ruby',       '.rake': 'ruby',
-    '.php': 'php',
-    '.swift': 'swift',
-    '.dart': 'dart',
-    '.scala': 'scala',   '.sc': 'scala',
-    '.gd': 'gdscript',
-    '.r': 'r',           '.R': 'r',
-    '.svelte': 'svelte',
-    '.html': 'html',     '.htm': 'html',
-    '.css': 'css',       '.scss': 'css', '.sass': 'css', '.less': 'css',
-    '.yml': 'yaml',      '.yaml': 'yaml',
-    '.sh': 'shell',      '.bash': 'shell', '.zsh': 'shell', '.fish': 'shell',
-    '.toml': 'toml',
-    '.properties': 'properties',
-    '.xml': 'xml',
-    '.md': 'markdown',
-    // Phase C specialized extractors
-    '.tsx': 'typescript_react',
-    '.vue': 'vue_sfc',
-  };
-
-  function isDockerfile(name) {
-    return name === 'Dockerfile' || name.startsWith('Dockerfile.');
-  }
+  // Extractor resolution goes through the dispatcher — the single source of
+  // truth (#591). This file previously kept its own copy, which had drifted to
+  // a dead duplicate `.vue` key.
+  const { langFor } = __require('./src/extractors/dispatch');
 
   function getExtractorName(filePath) {
-    const base = path.basename(filePath);
-    const ext  = path.extname(base).toLowerCase();
-    if (EXT_MAP[ext]) return EXT_MAP[ext];
-    if (isDockerfile(base)) return 'dockerfile';
-    return null;
+    return langFor(filePath);
   }
 
   /** Rough token estimate: chars / 4 */
@@ -5989,6 +5955,21 @@ __factories["./src/extractors/dispatch"] = function(module, exports) {
     generic: __require('./src/extractors/generic'),
   };
 
+  /**
+   * Extension → extractor module name. **The single source of truth for
+   * extractor resolution** (#591).
+   *
+   * Anything that decides *which extractor module to load* must go through
+   * `langFor` rather than declaring its own copy. Three copies existed and two
+   * had drifted: `src/eval/analyzer.js` carried a dead duplicate `.vue` key, and
+   * the `--diagnose-extractors` map pointed at `vue.js` after that module was
+   * deleted — which is how an unreachable extractor survived unnoticed (#582).
+   *
+   * Not every extension map in the codebase belongs here. `language-detector.js`
+   * maps `.tsx → typescript` for language *statistics*, and `dashboard.js` keeps
+   * short display *labels*. Both are correct for their purpose and deliberately
+   * differ from resolution — folding them in would miscount languages.
+   */
   const EXT_MAP = {
     '.ts': 'typescript', '.tsx': 'typescript_react',
     '.js': 'javascript', '.jsx': 'javascript', '.mjs': 'javascript', '.cjs': 'javascript',
@@ -6049,7 +6030,7 @@ __factories["./src/extractors/dispatch"] = function(module, exports) {
     }
   }
 
-  module.exports = { extractFile, langFor };
+  module.exports = { extractFile, langFor, EXT_MAP };
   
 };
 
@@ -26849,27 +26830,16 @@ function main() {
         process.exit(1);
       }
 
-      const EXT_TO_LANG = {
-        '.ts': 'typescript', '.js': 'javascript', '.py': 'python',
-        '.java': 'java', '.kt': 'kotlin', '.go': 'go', '.rs': 'rust',
-        '.cs': 'csharp', '.cpp': 'cpp', '.rb': 'ruby', '.php': 'php',
-        '.swift': 'swift', '.dart': 'dart', '.scala': 'scala',
-        '.r': 'r', '.R': 'r',
-        '.vue': 'vue_sfc', '.svelte': 'svelte', '.html': 'html',
-        '.css': 'css', '.yml': 'yaml', '.sh': 'shell',
-        '.tsx': 'typescript_react',
-        '.graphql': 'graphql', '.md': 'markdown', '.properties': 'properties',
-        '.proto': 'protobuf', '.sql': 'sql', '.tf': 'terraform',
-        '.toml': 'toml', '.xml': 'xml',
-      };
-      const SPECIAL = { 'Dockerfile': 'dockerfile' };
+      // Resolution goes through the dispatcher — the single source of truth
+      // (#591). This map was a third copy, and it still pointed at `vue.js`
+      // after that module was deleted, which is how a dead extractor survived.
+      const { langFor } = requireSourceOrBundled('./src/extractors/dispatch');
 
       let passed = 0; let failed = 0;
       const entries = fs.readdirSync(fixturesDir).sort();
 
       for (const filename of entries) {
-        const ext  = path.extname(filename).toLowerCase();
-        const lang = EXT_TO_LANG[ext] || SPECIAL[filename];
+        const lang = langFor(filename);
         if (!lang) continue;
 
         const fixturePath = path.join(fixturesDir, filename);

--- a/src/eval/analyzer.js
+++ b/src/eval/analyzer.js
@@ -14,47 +14,13 @@ const fs   = require('fs');
 const path = require('path');
 
 // Extension → extractor name (mirrors EXT_MAP in gen-context.js)
-const EXT_MAP = {
-  '.ts': 'typescript', '.tsx': 'typescript',
-  '.js': 'javascript', '.jsx': 'javascript', '.mjs': 'javascript', '.cjs': 'javascript',
-  '.py': 'python',     '.pyw': 'python',
-  '.java': 'java',
-  '.kt': 'kotlin',     '.kts': 'kotlin',
-  '.go': 'go',
-  '.rs': 'rust',
-  '.cs': 'csharp',
-  '.cpp': 'cpp', '.c': 'cpp', '.h': 'cpp', '.hpp': 'cpp', '.cc': 'cpp',
-  '.rb': 'ruby',       '.rake': 'ruby',
-  '.php': 'php',
-  '.swift': 'swift',
-  '.dart': 'dart',
-  '.scala': 'scala',   '.sc': 'scala',
-  '.gd': 'gdscript',
-  '.r': 'r',           '.R': 'r',
-  '.svelte': 'svelte',
-  '.html': 'html',     '.htm': 'html',
-  '.css': 'css',       '.scss': 'css', '.sass': 'css', '.less': 'css',
-  '.yml': 'yaml',      '.yaml': 'yaml',
-  '.sh': 'shell',      '.bash': 'shell', '.zsh': 'shell', '.fish': 'shell',
-  '.toml': 'toml',
-  '.properties': 'properties',
-  '.xml': 'xml',
-  '.md': 'markdown',
-  // Phase C specialized extractors
-  '.tsx': 'typescript_react',
-  '.vue': 'vue_sfc',
-};
-
-function isDockerfile(name) {
-  return name === 'Dockerfile' || name.startsWith('Dockerfile.');
-}
+// Extractor resolution goes through the dispatcher — the single source of
+// truth (#591). This file previously kept its own copy, which had drifted to
+// a dead duplicate `.vue` key.
+const { langFor } = require('../extractors/dispatch');
 
 function getExtractorName(filePath) {
-  const base = path.basename(filePath);
-  const ext  = path.extname(base).toLowerCase();
-  if (EXT_MAP[ext]) return EXT_MAP[ext];
-  if (isDockerfile(base)) return 'dockerfile';
-  return null;
+  return langFor(filePath);
 }
 
 /** Rough token estimate: chars / 4 */

--- a/src/extractors/dispatch.js
+++ b/src/extractors/dispatch.js
@@ -48,6 +48,21 @@ const EXTRACTORS = {
   generic: require('./generic'),
 };
 
+/**
+ * Extension → extractor module name. **The single source of truth for
+ * extractor resolution** (#591).
+ *
+ * Anything that decides *which extractor module to load* must go through
+ * `langFor` rather than declaring its own copy. Three copies existed and two
+ * had drifted: `src/eval/analyzer.js` carried a dead duplicate `.vue` key, and
+ * the `--diagnose-extractors` map pointed at `vue.js` after that module was
+ * deleted — which is how an unreachable extractor survived unnoticed (#582).
+ *
+ * Not every extension map in the codebase belongs here. `language-detector.js`
+ * maps `.tsx → typescript` for language *statistics*, and `dashboard.js` keeps
+ * short display *labels*. Both are correct for their purpose and deliberately
+ * differ from resolution — folding them in would miscount languages.
+ */
 const EXT_MAP = {
   '.ts': 'typescript', '.tsx': 'typescript_react',
   '.js': 'javascript', '.jsx': 'javascript', '.mjs': 'javascript', '.cjs': 'javascript',
@@ -108,4 +123,4 @@ function extractFile(filePathOrName, src) {
   }
 }
 
-module.exports = { extractFile, langFor };
+module.exports = { extractFile, langFor, EXT_MAP };

--- a/test/integration/extension-map-single-source.test.js
+++ b/test/integration/extension-map-single-source.test.js
@@ -1,0 +1,94 @@
+'use strict';
+
+/**
+ * Extractor resolution has one source of truth (#591).
+ *
+ * Three places decided which extractor module to load, and two had drifted:
+ * `src/eval/analyzer.js` carried a dead duplicate `.vue` key, and the
+ * `--diagnose-extractors` map still pointed at `vue.js` after that module was
+ * deleted. That drift is how an unreachable extractor survived unnoticed
+ * (#582), and how `.gd` went un-diagnosed despite having both a fixture and a
+ * recorded expected output.
+ *
+ * Not every extension map is a resolution map. `language-detector.js` maps
+ * `.tsx → typescript` for language *statistics* and `dashboard.js` keeps short
+ * display *labels*; both are correct for their purpose and must stay separate,
+ * so this test pins that distinction rather than demanding one global map.
+ */
+
+const assert = require('assert');
+const fs = require('fs');
+const path = require('path');
+
+const ROOT = path.join(__dirname, '..', '..');
+const dispatch = require(path.join(ROOT, 'src/extractors/dispatch'));
+
+let passed = 0;
+let failed = 0;
+function test(name, fn) {
+  try { fn(); console.log(`  PASS  ${name}`); passed++; }
+  catch (e) { console.log(`  FAIL  ${name}\n        ${e.message}`); failed++; }
+}
+
+const read = (rel) => fs.readFileSync(path.join(ROOT, rel), 'utf8');
+
+test('dispatch exports the resolution map', () => {
+  assert.strictEqual(typeof dispatch.EXT_MAP, 'object');
+  assert.ok(Object.keys(dispatch.EXT_MAP).length > 30,
+    `expected a full extension map, got ${Object.keys(dispatch.EXT_MAP).length} entries`);
+  assert.strictEqual(dispatch.EXT_MAP['.tsx'], 'typescript_react');
+  assert.strictEqual(dispatch.EXT_MAP['.vue'], 'vue_sfc');
+});
+
+test('no duplicate keys in the resolution map', () => {
+  // A duplicate key is silent in JS — last wins — which is exactly how the
+  // dead `.vue` entry in analyzer.js hid behind a live one.
+  const src = read('src/extractors/dispatch.js');
+  const block = src.slice(src.indexOf('const EXT_MAP = {'), src.indexOf('};', src.indexOf('const EXT_MAP = {')));
+  const keys = [...block.matchAll(/'(\.[A-Za-z0-9]+)'\s*:/g)].map((m) => m[1]);
+  const dupes = keys.filter((k, i) => keys.indexOf(k) !== i);
+  assert.deepStrictEqual([...new Set(dupes)], [], `duplicate extension key(s): ${dupes.join(', ')}`);
+});
+
+test('analyzer.js resolves through the dispatcher, not its own map', () => {
+  const src = read('src/eval/analyzer.js');
+  assert.ok(/require\(['"]\.\.\/extractors\/dispatch['"]\)/.test(src),
+    'analyzer.js does not require the dispatcher');
+  assert.ok(!/const\s+EXT_MAP\s*=\s*\{/.test(src),
+    'analyzer.js declares its own extension map again');
+});
+
+test('--diagnose-extractors resolves through the dispatcher', () => {
+  const src = read('gen-context.js');
+  const i = src.indexOf("if (args.includes('--diagnose-extractors'))");
+  assert.ok(i > 0, '--diagnose-extractors block not found');
+  const block = src.slice(i, i + 3000);
+  assert.ok(/langFor/.test(block), '--diagnose-extractors does not use langFor');
+  assert.ok(!/const\s+EXT_TO_LANG\s*=\s*\{/.test(block),
+    '--diagnose-extractors declares its own extension map again');
+});
+
+test('every fixture resolves, including .gd which the old map omitted', () => {
+  // gdscript had a fixture and an expected file but was absent from the
+  // hand-maintained diagnose map, so it was never actually diagnosed.
+  assert.strictEqual(dispatch.langFor('gdscript.gd'), 'gdscript');
+  const unresolved = fs.readdirSync(path.join(ROOT, 'test', 'fixtures'))
+    .filter((f) => !fs.statSync(path.join(ROOT, 'test', 'fixtures', f)).isDirectory())
+    .filter((f) => !dispatch.langFor(f));
+  assert.deepStrictEqual(unresolved, [], `fixture(s) the dispatcher cannot resolve: ${unresolved.join(', ')}`);
+});
+
+test('labelling maps stay separate from resolution, by design', () => {
+  // language-detector counts languages: TSX *is* TypeScript for that purpose.
+  // If someone "deduplicates" it into the resolution map, language stats break.
+  const detector = require(path.join(ROOT, 'src/discovery/language-detector.js'));
+  const src = read('src/discovery/language-detector.js');
+  assert.ok(/'\.tsx':\s*'typescript'/.test(src),
+    'language-detector should map .tsx to typescript for language statistics');
+  assert.strictEqual(dispatch.EXT_MAP['.tsx'], 'typescript_react',
+    'resolution must still map .tsx to the React extractor');
+  assert.ok(detector, 'language-detector should load');
+});
+
+console.log(`\n${passed} passed, ${failed} failed`);
+if (failed > 0) process.exit(1);

--- a/version.json
+++ b/version.json
@@ -5,7 +5,7 @@
   "languages": 32,
   "extractors": 42,
   "mcp_tools": 21,
-  "tests": 149,
+  "tests": 150,
   "metrics": {
     "hit_at_5": 0.789,
     "baseline_hit_at_5": 0.136,


### PR DESCRIPTION
## Summary

Three places decided which extractor module to load, and two had drifted. `src/eval/analyzer.js` carried a dead duplicate `.vue` key (last-wins hid it), and the `--diagnose-extractors` map still pointed at `vue.js` after that module was deleted. **That drift is how an unreachable extractor survived unnoticed (#582).**

`dispatch.js` now exports the map; every resolution consumer goes through `langFor`.

Closes #591.

## The duplicate map was also incomplete

It had no `.gd` entry, so **gdscript was never actually diagnosed** — despite having both a fixture and a recorded expected output since well before this work. Routing through the dispatcher took the diagnostic from 30 to 32 passing with no change to any extractor.

```
--diagnose-extractors:  30 passed  ->  32 passed, 0 failed
```

## Two maps deliberately NOT merged

This is the part worth reviewing. Not every extension map is a resolution map:

| Copy | Purpose | `.tsx` |
|---|---|---|
| `dispatch.js` | resolution — now the only one | `typescript_react` |
| `analyzer.js` | resolution | → now `langFor` |
| `--diagnose-extractors` | resolution | → now `langFor` |
| `language-detector.js` | language **statistics** | `typescript` ✅ correct |
| `dashboard.js` | display **labels** | `vue` ✅ correct |

`language-detector.js` is right that TSX *is* TypeScript when counting languages. Folding it into resolution would miscount. A test pins that distinction so a future "dedup" cannot quietly break language stats.

## Test plan

`test/integration/extension-map-single-source.test.js` — 6 assertions, **4 fail against the pre-fix code**:

- [x] `dispatch` exports the resolution map, with `.tsx`/`.vue` correct
- [x] No duplicate keys in it (a duplicate is silent in JS — exactly how the dead `.vue` entry hid)
- [x] `analyzer.js` requires the dispatcher and declares no map of its own
- [x] `--diagnose-extractors` uses `langFor` and declares no map of its own
- [x] Every fixture resolves, including `.gd`
- [x] Labelling maps stay separate, by design
- [x] `node test/integration/all.js` — **144 passed, 0 failed**
- [x] `validate:callgraph-jvm` — PASS
- [x] Supply-chain audit — clean

## ⚠️ Retrieval gate: local and CI disagree, and it is not this change

Locally the gate reports `mined` 56.5%; CI reported **60.9%** on the same commit (`hard` 73.3% vs 72.2%). I filed this as #596.

**This branch is not the cause** — `mined` is identically 56.5% locally at `94d41fb`, before the branch existed. I ruled out a stale index (#579's regeneration works; two local runs agree), the #588 fixtures (`test/` is not indexed — `srcDirs` is `src`/`packages`), learned weights (`loadWeights` returns `{}`), and the benchmark clones (excluded).

The cause is still unknown, which is why it is filed rather than hand-waved. CI is the arbiter here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)