### PR TITLE
fix(routes): compose the @Controller prefix into NestJS paths

### DIFF
--- a/gen-context.js
+++ b/gen-context.js
@@ -14435,6 +14435,45 @@ __factories["./src/map/route-table"] = function(module, exports) {
   }
 
   /**
+   * Byte offsets and prefixes of every `@Controller(...)` in a file.
+   * A file may declare several controllers, so each route is attributed to the
+   * nearest one above it rather than to a single file-wide prefix.
+   * @param {string} content
+   * @returns {Array<{index:number, prefix:string}>} ascending by index
+   */
+  function nestControllerPrefixes(content) {
+    const out = [];
+    const re = /@Controller\s*\(\s*(?:['"`]([^'"`]*)['"`])?/g;
+    let m;
+    while ((m = re.exec(content)) !== null) {
+      out.push({ index: m.index, prefix: m[1] || '' });
+    }
+    return out;
+  }
+
+  /** Prefix of the nearest `@Controller` above `index`, or '' when there is none. */
+  function prefixBefore(controllers, index) {
+    let prefix = '';
+    for (const c of controllers) {
+      if (c.index > index) break;
+      prefix = c.prefix;
+    }
+    return prefix;
+  }
+
+  /**
+   * Join a controller prefix and a method path into one route path.
+   * Either side may be empty, absent, or carry its own slashes.
+   * @returns {string} always slash-prefixed; never a trailing slash except '/'
+   */
+  function joinRoute(prefix, methodPath) {
+    const parts = [prefix, methodPath]
+      .map((p) => String(p || '').trim().replace(/^\/+|\/+$/g, ''))
+      .filter(Boolean);
+    return parts.length ? '/' + parts.join('/') : '/';
+  }
+
+  /**
    * Structured route rows across the supported frameworks — the data behind
    * `analyze`, exposed for retrieval surface-enrichment (#488).
    * @param {string[]} files absolute paths
@@ -14462,16 +14501,14 @@ __factories["./src/map/route-table"] = function(module, exports) {
           routes.push({ method: m[1].toUpperCase(), path: m[2], file: rel });
         }
 
-        // NestJS decorators: @Get('/path') @Post('/path')
-        const re2 = /@(Get|Post|Put|Patch|Delete|Head|Options|All)\s*\(\s*['"`]([^'"`]+)['"`]\s*\)/g;
+        // NestJS: @Get(':id') / @Post() — composed with the enclosing
+        // @Controller('prefix'). Without the prefix the emitted path matches
+        // nothing real, which defeats the point of route pseudo-signatures (#585).
+        const controllers = nestControllerPrefixes(content);
+        const re2 = /@(Get|Post|Put|Patch|Delete|Head|Options|All)\s*\(\s*(?:['"`]([^'"`]*)['"`])?\s*\)/g;
         while ((m = re2.exec(content)) !== null) {
-          routes.push({ method: m[1].toUpperCase(), path: m[2], file: rel });
-        }
-
-        // NestJS: @Get() with no path
-        const re3 = /@(Get|Post|Put|Patch|Delete)\s*\(\s*\)/g;
-        while ((m = re3.exec(content)) !== null) {
-          routes.push({ method: m[1].toUpperCase(), path: '/', file: rel });
+          const prefix = prefixBefore(controllers, m.index);
+          routes.push({ method: m[1].toUpperCase(), path: joinRoute(prefix, m[2]), file: rel });
         }
       }
 

--- a/src/map/route-table.js
+++ b/src/map/route-table.js
@@ -21,6 +21,45 @@ function shouldSkipFile(rel) {
 }
 
 /**
+ * Byte offsets and prefixes of every `@Controller(...)` in a file.
+ * A file may declare several controllers, so each route is attributed to the
+ * nearest one above it rather than to a single file-wide prefix.
+ * @param {string} content
+ * @returns {Array<{index:number, prefix:string}>} ascending by index
+ */
+function nestControllerPrefixes(content) {
+  const out = [];
+  const re = /@Controller\s*\(\s*(?:['"`]([^'"`]*)['"`])?/g;
+  let m;
+  while ((m = re.exec(content)) !== null) {
+    out.push({ index: m.index, prefix: m[1] || '' });
+  }
+  return out;
+}
+
+/** Prefix of the nearest `@Controller` above `index`, or '' when there is none. */
+function prefixBefore(controllers, index) {
+  let prefix = '';
+  for (const c of controllers) {
+    if (c.index > index) break;
+    prefix = c.prefix;
+  }
+  return prefix;
+}
+
+/**
+ * Join a controller prefix and a method path into one route path.
+ * Either side may be empty, absent, or carry its own slashes.
+ * @returns {string} always slash-prefixed; never a trailing slash except '/'
+ */
+function joinRoute(prefix, methodPath) {
+  const parts = [prefix, methodPath]
+    .map((p) => String(p || '').trim().replace(/^\/+|\/+$/g, ''))
+    .filter(Boolean);
+  return parts.length ? '/' + parts.join('/') : '/';
+}
+
+/**
  * Structured route rows across the supported frameworks — the data behind
  * `analyze`, exposed for retrieval surface-enrichment (#488).
  * @param {string[]} files absolute paths
@@ -48,16 +87,14 @@ function collectRoutes(files, cwd) {
         routes.push({ method: m[1].toUpperCase(), path: m[2], file: rel });
       }
 
-      // NestJS decorators: @Get('/path') @Post('/path')
-      const re2 = /@(Get|Post|Put|Patch|Delete|Head|Options|All)\s*\(\s*['"`]([^'"`]+)['"`]\s*\)/g;
+      // NestJS: @Get(':id') / @Post() — composed with the enclosing
+      // @Controller('prefix'). Without the prefix the emitted path matches
+      // nothing real, which defeats the point of route pseudo-signatures (#585).
+      const controllers = nestControllerPrefixes(content);
+      const re2 = /@(Get|Post|Put|Patch|Delete|Head|Options|All)\s*\(\s*(?:['"`]([^'"`]*)['"`])?\s*\)/g;
       while ((m = re2.exec(content)) !== null) {
-        routes.push({ method: m[1].toUpperCase(), path: m[2], file: rel });
-      }
-
-      // NestJS: @Get() with no path
-      const re3 = /@(Get|Post|Put|Patch|Delete)\s*\(\s*\)/g;
-      while ((m = re3.exec(content)) !== null) {
-        routes.push({ method: m[1].toUpperCase(), path: '/', file: rel });
+        const prefix = prefixBefore(controllers, m.index);
+        routes.push({ method: m[1].toUpperCase(), path: joinRoute(prefix, m[2]), file: rel });
       }
     }
 

--- a/test/integration/nestjs-route-prefix.test.js
+++ b/test/integration/nestjs-route-prefix.test.js
@@ -1,0 +1,114 @@
+'use strict';
+
+/**
+ * NestJS route paths compose the `@Controller` prefix (#585).
+ *
+ * Route detection claims NestJS (config.md, `retrieval.surfaceEnrichment`),
+ * but the prefix was never read: `@Controller('cats')` + `@Get(':id')` emitted
+ * `:id`. A pseudo-signature of `route GET :id` matches nothing a user would
+ * ask about, which defeats the point of the feature.
+ */
+
+const assert = require('assert');
+const fs = require('fs');
+const os = require('os');
+const path = require('path');
+
+const ROOT = path.join(__dirname, '..', '..');
+const { collectRoutes } = require(path.join(ROOT, 'src/map/route-table'));
+
+let passed = 0;
+let failed = 0;
+function test(name, fn) {
+  try { fn(); console.log(`  PASS  ${name}`); passed++; }
+  catch (e) { console.log(`  FAIL  ${name}\n        ${e.message}`); failed++; }
+}
+
+/** Collect routes from one synthetic file. */
+function routesFor(source, name = 'ctrl.ts') {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'sigmap-nest-'));
+  const file = path.join(dir, name);
+  fs.writeFileSync(file, source);
+  return collectRoutes([file], dir);
+}
+
+test('composes the controller prefix with the method path', () => {
+  const r = routesFor(`
+@Controller('cats')
+export class CatsController {
+  @Get(':id') findOne() {}
+}`);
+  assert.deepStrictEqual(r.map((x) => `${x.method} ${x.path}`), ['GET /cats/:id']);
+});
+
+test('a decorator with no path yields the bare prefix', () => {
+  const r = routesFor(`
+@Controller('cats')
+export class CatsController {
+  @Post() create() {}
+}`);
+  assert.deepStrictEqual(r.map((x) => `${x.method} ${x.path}`), ['POST /cats']);
+});
+
+test('nested method paths are preserved under the prefix', () => {
+  const r = routesFor(`
+@Controller('cats')
+export class CatsController {
+  @Delete(':id/paws/:pawId') removePaw() {}
+}`);
+  assert.deepStrictEqual(r.map((x) => x.path), ['/cats/:id/paws/:pawId']);
+});
+
+test('a bare @Controller() adds no prefix', () => {
+  const r = routesFor(`
+@Controller()
+export class RootController {
+  @Get('health') health() {}
+}`);
+  assert.deepStrictEqual(r.map((x) => x.path), ['/health']);
+});
+
+test('stray slashes on either side collapse', () => {
+  const r = routesFor(`
+@Controller('/admin/')
+export class AdminController {
+  @Get('/users/') list() {}
+}`);
+  assert.deepStrictEqual(r.map((x) => x.path), ['/admin/users']);
+});
+
+test('each controller in a file gets its own prefix', () => {
+  const r = routesFor(`
+@Controller('cats')
+export class CatsController {
+  @Get(':id') findOne() {}
+}
+@Controller('dogs')
+export class DogsController {
+  @Get(':id') findOne() {}
+}`);
+  assert.deepStrictEqual(r.map((x) => x.path), ['/cats/:id', '/dogs/:id']);
+});
+
+test('a bare @Controller() with no path decorator yields root', () => {
+  const r = routesFor(`
+@Controller()
+export class RootController {
+  @Get() index() {}
+}`);
+  assert.deepStrictEqual(r.map((x) => x.path), ['/']);
+});
+
+test('Express routes in the same file are unaffected', () => {
+  const r = routesFor(`
+app.get('/users/:id', (req, res) => res.json({}));
+@Controller('cats')
+export class CatsController {
+  @Get(':id') findOne() {}
+}`, 'mixed.ts');
+  const paths = r.map((x) => x.path).sort();
+  assert.deepStrictEqual(paths, ['/cats/:id', '/users/:id']);
+});
+
+console.log(`\n${passed} passed, ${failed} failed`);
+if (failed > 0) process.exit(1);

--- a/version.json
+++ b/version.json
@@ -5,7 +5,7 @@
   "languages": 32,
   "extractors": 42,
   "mcp_tools": 21,
-  "tests": 150,
+  "tests": 151,
   "metrics": {
     "hit_at_5": 0.789,
     "baseline_hit_at_5": 0.136,


### PR DESCRIPTION
## Summary

Route detection claims NestJS ([config.md](../blob/develop/docs-vp/guide/config.md), `retrieval.surfaceEnrichment`), but the `@Controller` prefix was never read:

```ts
@Controller('cats')
export class CatsController {
  @Get(':id') findOne() {}   // emitted ":id"   — expected "/cats/:id"
  @Post()     create()  {}   // emitted "/"     — expected "/cats"
}
```

A `route GET :id` pseudo-signature matches nothing a user would ask about, which defeats the point of the feature — it exists so a route-worded query can reach a controller whose signatures never mention the path.

Closes #585.

## Implementation

The prefix is attributed **per controller, not per file**, since a file may declare several — each route takes the nearest `@Controller` above it. The two decorator branches (with path / without path) collapse into one regex with an optional path group, so `@Get()` composes the same way `@Get(':id')` does.

```
@Controller('cats')  + @Get(':id')              ->  /cats/:id
@Controller('cats')  + @Post()                  ->  /cats
@Controller('cats')  + @Delete(':id/paws/:pid') ->  /cats/:id/paws/:pid
@Controller()        + @Get('health')           ->  /health
@Controller('/admin/') + @Get('/users/')        ->  /admin/users
```

## Test plan

`test/integration/nestjs-route-prefix.test.js` — 8 assertions, **7 fail against the pre-fix code**:

- [x] Prefix composes with the method path
- [x] A pathless decorator yields the bare prefix
- [x] Nested method paths preserved (`:id/paws/:pawId`)
- [x] Bare `@Controller()` adds no prefix
- [x] Stray slashes on either side collapse
- [x] Each controller in a file gets its own prefix
- [x] `@Controller()` + `@Get()` yields `/`
- [x] Express routes in the same file are unaffected
- [x] `node test/integration/all.js` — **145 passed, 0 failed**
- [x] Metadata gate clean, bundle rebuilt

## Scope

The other six claimed frameworks were verified in the same run and are **unchanged** — Express, Fastify, Spring, FastAPI, Flask and Gin already emitted correct paths. NestJS was the only one wrong.

Rails, Laravel, Django and Next.js still detect no routes. That remains a gap rather than a false claim: `config.md` scopes route detection to exactly the seven frameworks.

🤖 Generated with [Claude Code](https://claude.com/claude-code)